### PR TITLE
KB-10186 | Learner Portal | If user has Primary details, in the Service history default data is not calculating for Profile page percentage.

### DIFF
--- a/src/main/java/com/igot/cb/profile/service/ProfileServiceImpl.java
+++ b/src/main/java/com/igot/cb/profile/service/ProfileServiceImpl.java
@@ -588,7 +588,16 @@ public class ProfileServiceImpl implements ProfileService {
             boolean isFilled;
             try {
                 if (isExtendedProfileField(field)) {
-                    isFilled = hasExtendedProfileData(userId, field, userToken);
+                    isFilled = hasExtendedProfileData(userId, field, userToken)
+                            || (Constants.SERVICE_HISTORY.equalsIgnoreCase(field) &&
+                            Optional.ofNullable(profileData.get(Constants.PROFILE_DETAILS))
+                                    .filter(Map.class::isInstance)
+                                    .map(Map.class::cast)
+                                    .map(details -> details.get(Constants.PROFESSIONAL_DETAILS))
+                                    .filter(List.class::isInstance)
+                                    .map(List.class::cast)
+                                    .map(CollectionUtils::isNotEmpty)
+                                    .orElse(false));
                 } else {
                     Object value = profileData.getOrDefault(field, nestedData.get(field));
                     isFilled = value != null && !value.toString().trim().isEmpty();

--- a/src/main/java/com/igot/cb/util/Constants.java
+++ b/src/main/java/com/igot/cb/util/Constants.java
@@ -436,6 +436,7 @@ public class Constants {
     public static final String COMPETENCY_THEME_GROUPS = "competencyThemeGroups";
     public static final String INDEX = "index";
     public static final String PROFILE_COMPLETION_PERCENTAGE = "profileCompletionPercentage";
+    public static final String PROFESSIONAL_DETAILS = "professionalDetails";
 
     private Constants() {
     }


### PR DESCRIPTION

1. If user has Professional details and the Service history  data is not there then we need to add the profile completion percentage based on the professional details