### PR TITLE
 Network Hub Enhancements

### DIFF
--- a/src/main/java/com/igot/cb/profile/service/ProfileServiceImpl.java
+++ b/src/main/java/com/igot/cb/profile/service/ProfileServiceImpl.java
@@ -808,7 +808,7 @@ public class ProfileServiceImpl implements ProfileService {
                 totalPoints=(int) records.get(0).get(Constants.TOTAL_POINTS);
             }
 
-            cacheService.putCache(redisKey, String.valueOf(totalPoints));
+            cacheService.putCache(redisKey, totalPoints);
             return totalPoints;
         } catch (Exception e) {
             logger.warn("Failed to fetch karma points for userId {}: {}", userId, e.getMessage());


### PR DESCRIPTION
While persisting the data to the redis is was converting to the string two times so we were removing the special characters , remove the map to string conversion in service layer.

Reference PR : https://github.com/KB-iGOT/cb-ext-userprofile-service/pull/51