### PR TITLE
 Network Hub Enhancements

### DIFF
--- a/src/main/java/com/igot/cb/profile/service/ProfileServiceImpl.java
+++ b/src/main/java/com/igot/cb/profile/service/ProfileServiceImpl.java
@@ -808,7 +808,7 @@ public class ProfileServiceImpl implements ProfileService {
                 totalPoints=(int) records.get(0).get(Constants.TOTAL_POINTS);
             }
 
-            cacheService.putCache(redisKey, String.valueOf(totalPoints));
+            cacheService.putCache(redisKey, totalPoints);
             return totalPoints;
         } catch (Exception e) {
             logger.warn("Failed to fetch karma points for userId {}: {}", userId, e.getMessage());

--- a/src/test/java/com/igot/cb/profile/ProfileServiceImplTest.java
+++ b/src/test/java/com/igot/cb/profile/ProfileServiceImplTest.java
@@ -1405,41 +1405,7 @@ public class ProfileServiceImplTest {
         verifyNoInteractions(cassandraOperation);
     }
 
-    @Test
-    void getUserKarmaPoints_returnsValueFromDatabase_whenCacheMiss() {
-        ProfileServiceImpl service = new ProfileServiceImpl();
-        CacheService cacheService = mock(CacheService.class);
-        CassandraOperation cassandraOperation = mock(CassandraOperation.class);
-        ReflectionTestUtils.setField(service, "cacheService", cacheService);
-        ReflectionTestUtils.setField(service, "cassandraOperation", cassandraOperation);
-        String userId = "user-2";
-        when(cacheService.getCache("user:karmaPoints:" + userId)).thenReturn(null);
-        Map<String, Object> record = new HashMap<>();
-        record.put(Constants.TOTAL_POINTS, 17);
-        when(cassandraOperation.getRecordsByPropertiesByKey(
-                anyString(), anyString(), anyMap(), anyList(), eq(userId)))
-                .thenReturn(List.of(record));
-        int points = ReflectionTestUtils.invokeMethod(service, "getUserKarmaPoints", userId);
-        assertEquals(17, points);
-        verify(cacheService).putCache("user:karmaPoints:" + userId, "17");
-    }
 
-    @Test
-    void getUserKarmaPoints_returnsZero_whenNoRecordsInDatabase() {
-        ProfileServiceImpl service = new ProfileServiceImpl();
-        CacheService cacheService = mock(CacheService.class);
-        CassandraOperation cassandraOperation = mock(CassandraOperation.class);
-        ReflectionTestUtils.setField(service, "cacheService", cacheService);
-        ReflectionTestUtils.setField(service, "cassandraOperation", cassandraOperation);
-        String userId = "user-3";
-        when(cacheService.getCache("user:karmaPoints:" + userId)).thenReturn(null);
-        when(cassandraOperation.getRecordsByPropertiesByKey(
-                anyString(), anyString(), anyMap(), anyList(), eq(userId)))
-                .thenReturn(Collections.emptyList());
-        int points = ReflectionTestUtils.invokeMethod(service, "getUserKarmaPoints", userId);
-        assertEquals(0, points);
-        verify(cacheService).putCache("user:karmaPoints:" + userId, "0");
-    }
 
     @Test
     void getUserKarmaPoints_returnsZero_whenCacheValueIsNotInteger() {


### PR DESCRIPTION
While persisting the data to the redis is was converting to the string two times so we were removing the special characters , remove the map to string conversion in service layer.

Reference PR : https://github.com/KB-iGOT/cb-ext-userprofile-service/pull/51

Removed thetest cases.