### PR TITLE
 Network Hub Enhancements

### DIFF
--- a/src/main/java/com/igot/cb/profile/service/ProfileServiceImpl.java
+++ b/src/main/java/com/igot/cb/profile/service/ProfileServiceImpl.java
@@ -881,7 +881,7 @@ public class ProfileServiceImpl implements ProfileService {
             }
 
             int postCount = fetchPostCountFromApi(userId);
-            cacheService.putCache(redisKey, String.valueOf(postCount));
+            cacheService.putCache(redisKey, postCount);
             return postCount;
 
         } catch (Exception e) {


### PR DESCRIPTION
While persisting the data to the redis is was converting to the string two times int to string conversion in service layer.

Reference : https://github.com/KB-iGOT/cb-ext-userprofile-service/pull/53