### PR TITLE
KB-10669 | Learner portal > User Profile > For few users basic profile read API does not return ‘personalDetails’ in response.

### DIFF
--- a/src/main/java/com/igot/cb/profile/service/ProfileServiceImpl.java
+++ b/src/main/java/com/igot/cb/profile/service/ProfileServiceImpl.java
@@ -324,9 +324,9 @@ public class ProfileServiceImpl implements ProfileService {
         boolean isSelfUser = userIdFromToken.equalsIgnoreCase(userId);
         String cacheKey;
         if (isSelfUser) {
-            cacheKey = Constants.USER + ":basicProfile" + userId;
+            cacheKey = Constants.USER + ":basicProfile:" + userId;
         } else {
-            cacheKey = Constants.USER + ":basicProfile:notSelfUser" + userId;
+            cacheKey = Constants.USER + ":basicProfile:notSelfUser:" + userId;
         }
 
         try {

--- a/src/main/java/com/igot/cb/profile/service/ProfileServiceImpl.java
+++ b/src/main/java/com/igot/cb/profile/service/ProfileServiceImpl.java
@@ -322,7 +322,12 @@ public class ProfileServiceImpl implements ProfileService {
         }
 
         boolean isSelfUser = userIdFromToken.equalsIgnoreCase(userId);
-        String cacheKey = Constants.USER + ":basicProfile:" + userId;
+        String cacheKey;
+        if (isSelfUser) {
+            cacheKey = Constants.USER + ":basicProfile" + userId;
+        } else {
+            cacheKey = Constants.USER + ":basicProfile:notSelfUser" + userId;
+        }
 
         try {
             String cachedJson = cacheService.getCache(cacheKey);


### PR DESCRIPTION
1. Created new redis key  for saving the data wrt to viewing other user profile.
2. There is a issue when we search the user from logging in to a user and trying to view other profile.
3. When we login in the other profile the personal details are not being showed -> since the db call is not happening and data not available in the redis .
4. So created new redis Key to fix this issue.