### PR TITLE
Fixed cache issue: changed two times serialization to one

### DIFF
--- a/src/main/java/com/igot/cb/profile/service/ProfileServiceImpl.java
+++ b/src/main/java/com/igot/cb/profile/service/ProfileServiceImpl.java
@@ -278,7 +278,7 @@ public class ProfileServiceImpl implements ProfileService {
 
         result.put(Constants.USERID_KEY, userId);
         try {
-            cacheService.putCache(redisKey, mapper.writeValueAsString(result));
+            cacheService.putCache(redisKey, result);
         } catch (Exception e) {
             log.warn("Failed to cache extended profile summary for userId {}: {}", userId, e.getMessage());
         }

--- a/src/main/java/com/igot/cb/profile/service/ProfileServiceImpl.java
+++ b/src/main/java/com/igot/cb/profile/service/ProfileServiceImpl.java
@@ -317,7 +317,7 @@ public class ProfileServiceImpl implements ProfileService {
                 return response;
             }
             try {
-                cacheService.putCache(redisKey, mapper.writeValueAsString(contextData));
+                cacheService.putCache(redisKey, contextData);
             } catch (Exception e) {
                 log.warn("Failed to cache data for key {}: {}", redisKey, e.getMessage());
             }
@@ -435,7 +435,7 @@ public class ProfileServiceImpl implements ProfileService {
                     ProjectUtil.errorResponse(response, "No competencies found for user.", HttpStatus.NO_CONTENT);
                     return response;
                 }
-                cacheService.putCache(cacheKey, mapper.writeValueAsString(competencies));
+                cacheService.putCache(cacheKey, competencies);
             }
 
             response.setResponseCode(HttpStatus.OK);
@@ -523,7 +523,7 @@ public class ProfileServiceImpl implements ProfileService {
             updatedContext.put(Constants.DATA, updatedContextData);
             updatedContext.put(Constants.COUNT, updatedContextData != null ? updatedContextData.size() : 0);
             allProfileData.put(contextType, updatedContext);
-            cacheService.putCache(allKey, mapper.writeValueAsString(allProfileData));
+            cacheService.putCache(allKey, allProfileData);
         } catch (Exception e) {
             log.error("Error updating extendedProfile all cache for userId {}: {}", userId, e.getMessage());
         }

--- a/src/test/java/com/igot/cb/profile/ProfileServiceImplTest.java
+++ b/src/test/java/com/igot/cb/profile/ProfileServiceImplTest.java
@@ -530,8 +530,8 @@ class ProfileServiceImplTest {
         when(cassandraOperation.getRecordsByPropertiesByKey(any(), any(), any(), any(), any()))
                 .thenReturn(List.of(Map.of(Constants.CONTEXT_DATA, json)));
         try {
-            when(projectUtil.parseListOfMap(json)).thenReturn(List.of(Map.of("location", "India")));
-            when(objectMapper.writeValueAsString(any())).thenReturn(json);
+            lenient().when(projectUtil.parseListOfMap(json)).thenReturn(List.of(Map.of("location", "India")));
+            lenient().when(objectMapper.writeValueAsString(any())).thenReturn(json);
         } catch (Exception e) {
             fail("Should not throw exception");
         }
@@ -1038,11 +1038,11 @@ class ProfileServiceImplTest {
                 new ArrayList<>(List.of(new HashMap<>(Map.of("field", "value"))))
         );
         when(accessTokenValidator.fetchUserIdFromAccessToken(userToken)).thenReturn(userId);
-        doThrow(new RuntimeException("Cache error")).when(cacheService).putCache(anyString(), anyString());
+        doThrow(new RuntimeException("Cache error")).when(cacheService).putCache(anyString(), any());
         ApiResponse response = profileService.getExtendedProfileSummary(userId, userToken);
         assertEquals(HttpStatus.OK, response.getResponseCode());
         assertNotNull(response.get(Constants.RESPONSE));
-        verify(cacheService).putCache(anyString(), isNull());
+        verify(cacheService).putCache(anyString(), any());
     }
 
     @Test


### PR DESCRIPTION
cacheService.putCache() internally serializes an object into a JSON string. However, the developer passed a serialized object when calling this method, which caused a parsing exception during the deserialization of the cached data.

(<img width="1822" height="560" alt="Screenshot from 2025-09-24 13-37-26" src="https://github.com/user-attachments/assets/46090994-5f26-47e0-b47f-be99f28a31c0" />)

KB-11579: Cache Issue fix for the API (getExtendedProfile) and Improved code coverage