### PR TITLE
KB-11784 | Q9 | Tech Debt | BE | Performance improvement in Profile APIs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,11 @@
             <artifactId>jedis</artifactId>
             <version>4.4.3</version>
         </dependency>
+        <dependency>
+            <groupId>org.redisson</groupId>
+            <artifactId>redisson-spring-boot-starter</artifactId>
+            <version>3.27.2</version>
+        </dependency>
     <dependency>
         <groupId>org.elasticsearch</groupId>
         <artifactId>elasticsearch</artifactId>

--- a/src/main/java/com/igot/cb/profile/controller/ProfileController.java
+++ b/src/main/java/com/igot/cb/profile/controller/ProfileController.java
@@ -18,29 +18,29 @@ public class ProfileController {
     private ProfileService profileService;
 
     @PostMapping("/extended")
-    public ResponseEntity<?> saveExtendedProfile(
+    public ResponseEntity<ApiResponse> saveExtendedProfile(
             @RequestHeader(value = Constants.X_AUTH_TOKEN, required = true) String authToken,
-            @RequestBody Map<String, Object> request) throws Exception {
+            @RequestBody Map<String, Object> request) {
         ApiResponse response = profileService.saveExtendedProfile(request, authToken);
         return new ResponseEntity<>(response, response.getResponseCode());
     }
 
     @GetMapping("/extended/all/{userId}")
-    public ResponseEntity<Object> getExtendedProfileSummary(@PathVariable(Constants.USER_ID_RQST) String userId,
+    public ResponseEntity<ApiResponse> getExtendedProfileSummary(@PathVariable(Constants.USER_ID_RQST) String userId,
             @RequestHeader(value = Constants.X_AUTH_TOKEN, required = true) String authToken) {
         ApiResponse response = profileService.getExtendedProfileSummary(userId, authToken);
         return new ResponseEntity<>(response, HttpStatus.valueOf(response.getResponseCode().value()));
     }
 
     @GetMapping("/extended/serviceHistory/{userId}")
-    public ResponseEntity<Object> getServiceHistory(@PathVariable(Constants.USER_ID_RQST) String userId,
+    public ResponseEntity<ApiResponse> getServiceHistory(@PathVariable(Constants.USER_ID_RQST) String userId,
             @RequestHeader(value = Constants.X_AUTH_TOKEN, required = true) String authToken) {
         ApiResponse response = profileService.readFullExtendedProfile(userId, Constants.SERVICE_HISTORY, authToken);
         return new ResponseEntity<>(response, HttpStatus.valueOf(response.getResponseCode().value()));
     }
 
     @GetMapping("/extended/education/{userId}")
-    public ResponseEntity<Object> getEducationalQualifications(@PathVariable(Constants.USER_ID_RQST) String userId,
+    public ResponseEntity<ApiResponse> getEducationalQualifications(@PathVariable(Constants.USER_ID_RQST) String userId,
             @RequestHeader(value = Constants.X_AUTH_TOKEN, required = true) String authToken) {
         ApiResponse response = profileService.readFullExtendedProfile(userId, Constants.EDUCATION_QUALIFICATION,
                 authToken);
@@ -48,29 +48,29 @@ public class ProfileController {
     }
 
     @GetMapping("/extended/locationDetails/{userId}")
-    public ResponseEntity<Object> getLocationDetails(@PathVariable(Constants.USER_ID_RQST) String userId,
+    public ResponseEntity<ApiResponse> getLocationDetails(@PathVariable(Constants.USER_ID_RQST) String userId,
             @RequestHeader(value = Constants.X_AUTH_TOKEN, required = true) String authToken) {
         ApiResponse response = profileService.readFullExtendedProfile(userId, Constants.LOCATION_DETAILS, authToken);
         return new ResponseEntity<>(response, HttpStatus.valueOf(response.getResponseCode().value()));
     }
 
     @GetMapping("/extended/achievements/{userId}")
-    public ResponseEntity<Object> getAchievements(@PathVariable(Constants.USER_ID_RQST) String userId,
+    public ResponseEntity<ApiResponse> getAchievements(@PathVariable(Constants.USER_ID_RQST) String userId,
             @RequestHeader(value = Constants.X_AUTH_TOKEN, required = true) String authToken) {
         ApiResponse response = profileService.readFullExtendedProfile(userId, Constants.ACHIEVEMENTS, authToken);
         return new ResponseEntity<>(response, HttpStatus.valueOf(response.getResponseCode().value()));
     }
 
     @PutMapping("/extended")
-    public ResponseEntity<?> updateExtendedProfile(
+    public ResponseEntity<ApiResponse> updateExtendedProfile(
             @RequestHeader(value = Constants.X_AUTH_TOKEN, required = true) String authToken,
-            @RequestBody Map<String, Object> request) throws Exception {
+            @RequestBody Map<String, Object> request) {
         ApiResponse response = profileService.updateExtendedProfile(request, authToken);
         return new ResponseEntity<>(response, response.getResponseCode());
     }
 
     @DeleteMapping("/extended")
-    public ResponseEntity<?> deleteExtendedProfile(
+    public ResponseEntity<ApiResponse> deleteExtendedProfile(
             @RequestHeader(value = Constants.X_AUTH_TOKEN, required = true) String authToken,
             @RequestBody Map<String, Object> request) {
 
@@ -79,14 +79,14 @@ public class ProfileController {
     }
 
     @GetMapping("/basic/{userId}")
-    public ResponseEntity<Object> getBasicProfile(@PathVariable(Constants.USER_ID_RQST) String userId,
+    public ResponseEntity<ApiResponse> getBasicProfile(@PathVariable(Constants.USER_ID_RQST) String userId,
             @RequestHeader(value = Constants.X_AUTH_TOKEN, required = true) String authToken) {
         ApiResponse response = profileService.getBasicProfile(userId, authToken);
         return new ResponseEntity<>(response, response.getResponseCode());
     }
 
     @GetMapping("/extended/competencies/{userId}")
-    public ResponseEntity<Object> getCompetencies(@PathVariable(Constants.USER_ID_RQST) String userId,
+    public ResponseEntity<ApiResponse> getCompetencies(@PathVariable(Constants.USER_ID_RQST) String userId,
             @RequestHeader(value = Constants.X_AUTH_TOKEN, required = true) String authToken) {
         ApiResponse response = profileService.listCompetencies(userId, authToken);
         return new ResponseEntity<>(response, HttpStatus.valueOf(response.getResponseCode().value()));
@@ -101,7 +101,7 @@ public class ProfileController {
     }
 
     @GetMapping("/getAdditionalFields/{userId}/{orgId}")
-    public ResponseEntity<Object> getAdditionalFieldsByOrg(
+    public ResponseEntity<ApiResponse> getAdditionalFieldsByOrg(
             @PathVariable String userId,
             @PathVariable String orgId,
             @RequestHeader(value = Constants.X_AUTH_TOKEN) String authToken) {

--- a/src/main/java/com/igot/cb/profile/service/ProfileServiceImpl.java
+++ b/src/main/java/com/igot/cb/profile/service/ProfileServiceImpl.java
@@ -21,6 +21,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import com.igot.cb.common.OutboundRequestHandlerServiceImpl;
+import com.igot.cb.transactional.redis.cache.RedissonRedisDataService;
 import com.igot.cb.util.*;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
@@ -83,6 +84,9 @@ public class ProfileServiceImpl implements ProfileService {
 
     @Autowired
     OutboundRequestHandlerServiceImpl outboundRequestHandlerService;
+
+    @Autowired
+    private RedissonRedisDataService redisDataService;
 
     // -------------------- Service METHODS --------------------
 
@@ -293,7 +297,7 @@ public class ProfileServiceImpl implements ProfileService {
         ApiResponse response = ProjectUtil.createDefaultResponse("api.extendedProfile.read");
         String userIdFromToken = accessTokenValidator.fetchUserIdFromAccessToken(userToken);
 
-        if (userIdFromToken == null) {
+        if (StringUtils.isEmpty(userIdFromToken)) {
             ProjectUtil.errorResponse(response, "Invalid UserId in the request", HttpStatus.BAD_REQUEST);
             return response;
         }
@@ -339,20 +343,16 @@ public class ProfileServiceImpl implements ProfileService {
         ApiResponse response = ProjectUtil.createDefaultResponse("api.getBasicProfile.read");
         String userIdFromToken = accessTokenValidator.fetchUserIdFromAccessToken(userToken);
 
-        if (userIdFromToken == null) {
+        if (StringUtils.isEmpty(userIdFromToken)) {
             ProjectUtil.errorResponse(response, "Invalid or missing access token", HttpStatus.UNAUTHORIZED);
             return response;
         }
 
         boolean isSelfUser = userIdFromToken.equalsIgnoreCase(userId);
-        String cacheKey = Constants.USER + ":basicProfile:" + userId;
-
+        String cacheKey = Constants.USER + ":basicProfileV2:" + userId;
         try {
-            String cachedJson = cacheService.getCache(cacheKey);
-            Map<String, Object> userProfile;
-            if (StringUtils.isNotEmpty(cachedJson)) {
-                userProfile = mapper.readValue(cachedJson, new TypeReference<Map<String, Object>>() {
-                });
+            Map<String, Object> userProfile = redisDataService.getMap(cacheKey);
+            if (MapUtils.isNotEmpty(userProfile)) {
                 List<String> cachedKeyList = new ArrayList<>(userProfile.keySet());
                 List<String> differenceList = serverConfig.getBasicProfileFields().stream()
                         .filter(key -> !cachedKeyList.contains(key)).toList();
@@ -365,7 +365,7 @@ public class ProfileServiceImpl implements ProfileService {
             } else {
                 userProfile = readUserDataFromDB(userId, null);
             }
-            UserUtility.decryptSpecificUserData(userProfile, Arrays.asList(Constants.USERNAME_LOWERCASE));
+            UserUtility.decryptSpecificUserData(userProfile, List.of(Constants.USERNAME_LOWERCASE));
             if (MapUtils.isEmpty(userProfile)) {
                 response.setResponseCode(HttpStatus.NOT_FOUND);
                 response.put(Constants.RESPONSE, Collections.emptyMap());
@@ -585,7 +585,7 @@ public class ProfileServiceImpl implements ProfileService {
         if (CollectionUtils.isEmpty(keyList)) {
             keyList = serverConfig.getBasicProfileFields();
         }
-        String cacheKey = Constants.USER + ":basicProfile:" + userId;
+        String cacheKey = Constants.USER + ":basicProfileV2:" + userId;
         Map<String, Object> queryParams = Map.of(Constants.ID, userId);
         List<Map<String, Object>> userList = cassandraOperation.getRecordsByPropertiesByKey(
                 Constants.KEYSPACE_SUNBIRD, Constants.USER, queryParams, keyList, null);
@@ -604,7 +604,7 @@ public class ProfileServiceImpl implements ProfileService {
             } else {
                 userObj.put(Constants.PROFILE_DETAILS, Map.of());
             }
-            cacheService.putCache(cacheKey, userObj);
+            redisDataService.putMap(cacheKey, userObj);
         } catch (IOException e) {
             log.error("Invalid profileDetails JSON for userId: {}", userId, e);
             userObj.put(Constants.PROFILE_DETAILS, Map.of());
@@ -615,72 +615,17 @@ public class ProfileServiceImpl implements ProfileService {
 
     private void sanitizeProfile(Map<String, Object> profile, String userToken) {
         Object detailsObj = profile.get(Constants.PROFILE_DETAILS);
-
-        if (detailsObj instanceof Map<?, ?> detailsMap) {
-            if (detailsMap.containsKey(Constants.PERSONAL_DETAILS)) {
-                detailsMap.remove(Constants.PERSONAL_DETAILS);
-                log.info("Removed personalDetails due to unrecognized profilePreference.");
-            }
-            ProfilePreference profilePref = ProfilePreference.PUBLIC; // default to PUBLIC
-
-            Object preferenceObj = detailsMap.get(Constants.PROFILE_PREFERENCE);
-            if (preferenceObj instanceof Integer) {
-                ProfilePreference resolvedPref = ProfilePreference.fromValue((Integer) preferenceObj);
-                if (resolvedPref != null) {
-                    profilePref = resolvedPref;
-                }
-            }
-
-            // If PUBLIC, return everything
-            if (ProfilePreference.PUBLIC.equals(profilePref)) {
-                return;
-            }
-
-            // Load keys from property
-            List<String> filteredKeys = Arrays.asList(basicDetailsFilteredKeys.split(","));
-            // Shared allowed keys from config
-            List<String> allowedKeys = Arrays.asList(profileVisibleAllowedFields.split(","));
-            Map<String, Object> filteredDetails = new HashMap<>();
-
-            // If PRIVATE_NO_ONE
-            if (ProfilePreference.PRIVATE_NO_ONE.equals(profilePref)) {
-                for (String key : allowedKeys) {
-                    if (detailsMap.containsKey(key)) {
-                        filteredDetails.put(key, detailsMap.get(key));
-                    }
-                }
-                filteredKeys.forEach(profile::remove);
-                profile.put(Constants.PROFILE_DETAILS, filteredDetails);
-                log.info("Sanitized profileDetails for PRIVATE_NO_ONE ({}). Allowed fields: {}", profilePref.getValue(), allowedKeys);
-
-            } else if (ProfilePreference.PRIVATE_CONNECTIONS.equals(profilePref)) {
-                Map<String, Object> connectionResponse = checkConnected(
-                        (String) profile.get(Constants.ID),
-                        (String) profile.get(Constants.AUTH_TOKEN),
-                        userToken);
-
-                if (connectionResponse != null) {
-                    Object statusObj = connectionResponse.get(Constants.STATUS);
-                    if (statusObj != null && Constants.APPROVED.equalsIgnoreCase(statusObj.toString())) {
-                        return; // If connection approved, allow full profile
-                    }
-                }
-                filteredKeys.forEach(profile::remove);
-                for (String key : allowedKeys) {
-                    if (detailsMap.containsKey(key)) {
-                        filteredDetails.put(key, detailsMap.get(key));
-                    }
-                }
-                profile.put(Constants.PROFILE_DETAILS, filteredDetails);
-                log.info("Sanitized profileDetails for PRIVATE_CONNECTIONS ({}). Allowed fields: {}", profilePref.getValue(), allowedKeys);
-
-            } else {
-                // Fallback case – remove personalDetails
-                if (detailsMap.containsKey(Constants.PERSONAL_DETAILS)) {
-                    detailsMap.remove(Constants.PERSONAL_DETAILS);
-                    log.info("Removed personalDetails due to unrecognized profilePreference.");
-                }
-            }
+        if (!(detailsObj instanceof Map<?, ?> detailsMap)) return;
+        removePersonalDetailsIfPresent(detailsMap);
+        ProfilePreference profilePref = resolveProfilePreference(detailsMap);
+        if (ProfilePreference.PUBLIC.equals(profilePref)) return;
+        List<String> filteredKeys = Arrays.asList(basicDetailsFilteredKeys.split(","));
+        List<String> allowedKeys = Arrays.asList(profileVisibleAllowedFields.split(","));
+        switch (profilePref) {
+            case PRIVATE_NO_ONE -> sanitizePrivateNoOne(profile, detailsMap, filteredKeys, allowedKeys, profilePref);
+            case PRIVATE_CONNECTIONS ->
+                    sanitizePrivateConnections(profile, detailsMap, filteredKeys, allowedKeys, userToken, profilePref);
+            default -> removePersonalDetailsIfPresent(detailsMap);
         }
     }
 
@@ -715,56 +660,25 @@ public class ProfileServiceImpl implements ProfileService {
 
     protected double calculateProfileCompletionPercentage(Map<String, Object> profileData,
                                                           String userId, String userToken) {
+        String completionPercentageRedisKey = "user:profileCompletionPercentage:" + userId;
+        String completionPercentage = cacheService.getCache(completionPercentageRedisKey);
+        if (StringUtils.isNotEmpty(completionPercentage)) return Double.parseDouble(completionPercentage);
         List<String> requiredFields = serverConfig.getProfileCompletionRequiredFields();
-        if (profileData == null || requiredFields == null || requiredFields.isEmpty())
-            return 0.0;
-
+        if (MapUtils.isEmpty(profileData) || CollectionUtils.isEmpty(requiredFields)) return 0.0;
         double totalCompletion = 0.0;
-        Map<String, Object> nestedData = Optional.ofNullable(profileData.get(Constants.PROFILE_DETAILS))
-                .filter(Map.class::isInstance)
-                .map(Map.class::cast)
-                .orElse(Collections.emptyMap());
-
+        Map<String, Object> nestedData = getNestedProfileDetails(profileData);
         for (String field : requiredFields) {
-            boolean isFilled;
             try {
-                if (isExtendedProfileField(field)) {
-                    isFilled = hasExtendedProfileData(userId, field, userToken)
-                            || (Constants.SERVICE_HISTORY.equalsIgnoreCase(field) &&
-                            Optional.ofNullable(profileData.get(Constants.PROFILE_DETAILS))
-                                    .filter(Map.class::isInstance)
-                                    .map(Map.class::cast)
-                                    .map(details -> details.get(Constants.PROFESSIONAL_DETAILS))
-                                    .filter(List.class::isInstance)
-                                    .map(List.class::cast)
-                                    .map(CollectionUtils::isNotEmpty)
-                                    .orElse(false));
-                } else {
-                    if (Constants.EMPLOYMENT_DETAILS.equalsIgnoreCase(field)) {
-                        isFilled = Optional.ofNullable(profileData.get(Constants.PROFILE_DETAILS))
-                                .filter(Map.class::isInstance)
-                                .map(Map.class::cast)
-                                .map(details -> details.get(Constants.EMPLOYMENT_DETAILS))
-                                .filter(Map.class::isInstance)
-                                .map(Map.class::cast)
-                                .map(empDetails -> empDetails.get(Constants.ABOUT_ME))
-                                .map(Object::toString)
-                                .filter(aboutMe -> !aboutMe.trim().isEmpty())
-                                .isPresent();
-                    }else {
-                        Object value = profileData.getOrDefault(field, nestedData.get(field));
-                        isFilled = value != null && !value.toString().trim().isEmpty();
-                    }
+                if (isFieldsCompleted(field, profileData, nestedData, userId, userToken)) {
+                    totalCompletion += serverConfig.getFieldWeight();
                 }
             } catch (Exception e) {
                 log.warn("Exception checking field '{}' for user '{}': {}", field, userId, e.getMessage());
-                isFilled = false;
             }
-            if (isFilled)
-                totalCompletion += serverConfig.getFieldWeight();
         }
-
-        return Math.min(100.0, Math.round(totalCompletion * 10.0) / 10.0);
+        double calculatedCompletionPercentage = Math.min(100.0, Math.round(totalCompletion * 10.0) / 10.0);
+        cacheService.putCache(completionPercentageRedisKey, calculatedCompletionPercentage);
+        return calculatedCompletionPercentage;
     }
 
     private boolean isExtendedProfileField(String field) {
@@ -1059,11 +973,14 @@ public class ProfileServiceImpl implements ProfileService {
     }
 
     public List<String> getUserRoles(String userId, String rootOrgId) {
+        String userRolesRedisKey = "user:profileRoles:" + userId;
+        List<String> cachedRoles = redisDataService.getStringList(userRolesRedisKey);
+        if (CollectionUtils.isNotEmpty(cachedRoles)) return cachedRoles;
         List<Map<String, Object>> userRoleList = cassandraOperation.getRecordsByPropertiesByKey(
                 Constants.KEYSPACE_SUNBIRD, Constants.USER_ROLES,
                 Map.of(Constants.USERID_KEY, userId), List.of(Constants.ROLE, Constants.SCOPE), userId
         );
-        return userRoleList.stream()
+        List<String> roles = userRoleList.stream()
                 .map(userRoleObj -> {
                     Object userRoleScope = userRoleObj.get(Constants.SCOPE);
                     List<Map<String, Object>> scopes = new ArrayList<>();
@@ -1086,6 +1003,8 @@ public class ProfileServiceImpl implements ProfileService {
                 .filter(Objects::nonNull)
                 .distinct()
                 .toList();
+        if (CollectionUtils.isNotEmpty(roles)) redisDataService.putStringList(userRolesRedisKey, roles);
+        return roles;
     }
 
     private void mergeAndSortByIssuedDateOrTitle(List<Map<String, Object>> existingList, List<Map<String, Object>> newList) {
@@ -1496,5 +1415,117 @@ public class ProfileServiceImpl implements ProfileService {
             result.add(orgFields);
         }
         return result;
+    }
+
+
+    private Map<String, Object> getNestedProfileDetails(Map<String, Object> profileData) {
+        Object details = profileData.get(Constants.PROFILE_DETAILS);
+        if (details instanceof Map<?, ?> detailsMap) {
+            try {
+                return (Map<String, Object>) detailsMap;
+            } catch (ClassCastException e) {
+                log.error("Failed to cast PROFILE_DETAILS to Map<String, Object>: {}", e.getMessage());
+            }
+        }
+        return Collections.emptyMap();
+    }
+
+    private boolean isFieldsCompleted(String field, Map<String, Object> profileData, Map<String, Object> nestedData, String userId, String userToken) {
+        if (isExtendedProfileField(field)) {
+            return isExtendedFieldFilled(field, profileData, userId, userToken);
+        }
+        if (Constants.EMPLOYMENT_DETAILS.equalsIgnoreCase(field)) return isEmploymentFieldFilled(profileData);
+        Object value = profileData.getOrDefault(field, nestedData.get(field));
+        return value != null && !value.toString().trim().isEmpty();
+    }
+
+    private boolean isExtendedFieldFilled(String field, Map<String, Object> profileData, String userId, String userToken) {
+        if (hasExtendedProfileData(userId, field, userToken)) return true;
+        if (Constants.SERVICE_HISTORY.equalsIgnoreCase(field)) {
+            Object details = profileData.get(Constants.PROFILE_DETAILS);
+            if (details instanceof Map<?, ?> profileDetails) {
+                Object professionalDetails = profileDetails.get(Constants.PROFESSIONAL_DETAILS);
+                if (professionalDetails instanceof List<?> profList) {
+                    return CollectionUtils.isNotEmpty(profList);
+                }
+            }
+        }
+        return false;
+    }
+
+    private boolean isEmploymentFieldFilled(Map<String, Object> profileData) {
+        Object details = profileData.get(Constants.PROFILE_DETAILS);
+        if (details instanceof Map<?, ?> profileDetails) {
+            Object employment = profileDetails.get(Constants.EMPLOYMENT_DETAILS);
+            if (employment instanceof Map<?, ?> employmentDetails) {
+                Object aboutMe = employmentDetails.get(Constants.ABOUT_ME);
+                return aboutMe != null && !aboutMe.toString().trim().isEmpty();
+
+            }
+        }
+        return false;
+    }
+
+    private void removePersonalDetailsIfPresent(Map<?, ?> detailsMap) {
+        if (detailsMap.containsKey(Constants.PERSONAL_DETAILS)) {
+            detailsMap.remove(Constants.PERSONAL_DETAILS);
+            log.info("Removed personalDetails due to unrecognized profilePreference.");
+        }
+    }
+
+    private ProfilePreference resolveProfilePreference(Map<?, ?> detailsMap) {
+        Object preferenceObj = detailsMap.get(Constants.PROFILE_PREFERENCE);
+        if (preferenceObj instanceof Integer prefValue) {
+            ProfilePreference resolved = ProfilePreference.fromValue(prefValue);
+            return resolved != null ? resolved : ProfilePreference.PUBLIC;
+        }
+        return ProfilePreference.PUBLIC;
+    }
+
+    private void sanitizePrivateNoOne(Map<String, Object> profile,
+                                      Map<?, ?> detailsMap,
+                                      List<String> filteredKeys,
+                                      List<String> allowedKeys,
+                                      ProfilePreference profilePref) {
+        Map<String, Object> filteredDetails = extractAllowedDetails(detailsMap, allowedKeys);
+        filteredKeys.forEach(profile::remove);
+        profile.put(Constants.PROFILE_DETAILS, filteredDetails);
+        log.info("Sanitized profileDetails for PRIVATE_NO_ONE ({}). Allowed fields: {}", profilePref.getValue(), allowedKeys);
+    }
+
+    private Map<String, Object> extractAllowedDetails(Map<?, ?> detailsMap, List<String> allowedKeys) {
+        Map<String, Object> filtered = new HashMap<>();
+        for (String key : allowedKeys) {
+            if (detailsMap.containsKey(key)) {
+                filtered.put(key, detailsMap.get(key));
+            }
+        }
+        return filtered;
+    }
+
+    private void sanitizePrivateConnections(Map<String, Object> profile,
+                                            Map<?, ?> detailsMap,
+                                            List<String> filteredKeys,
+                                            List<String> allowedKeys,
+                                            String userToken,
+                                            ProfilePreference profilePref) {
+        if (isConnectionApproved(profile, userToken)) return;
+        filteredKeys.forEach(profile::remove);
+        Map<String, Object> filteredDetails = extractAllowedDetails(detailsMap, allowedKeys);
+        profile.put(Constants.PROFILE_DETAILS, filteredDetails);
+        log.info("Sanitized profileDetails for PRIVATE_CONNECTIONS ({}). Allowed fields: {}",
+                profilePref.getValue(), allowedKeys);
+
+    }
+
+    private boolean isConnectionApproved(Map<String, Object> profile, String userToken) {
+        Map<String, Object> connectionResponse = checkConnected(
+                (String) profile.get(Constants.ID),
+                (String) profile.get(Constants.AUTH_TOKEN),
+                userToken);
+
+        if (connectionResponse == null) return false;
+        Object statusObj = connectionResponse.get(Constants.STATUS);
+        return statusObj != null && Constants.APPROVED.equalsIgnoreCase(statusObj.toString());
     }
 }

--- a/src/main/java/com/igot/cb/profile/service/ProfileServiceImpl.java
+++ b/src/main/java/com/igot/cb/profile/service/ProfileServiceImpl.java
@@ -128,15 +128,12 @@ public class ProfileServiceImpl implements ProfileService {
             }else{
                 existingList.addAll(dataWithUUIDs);
             }
-
-            //sortContextData(existingList, contextType);
             if (!saveContextData(userId, contextType, existingList)) {
                 ProjectUtil.errorResponse(response, "Failed to save data for contextType: " + contextType,
                         HttpStatus.INTERNAL_SERVER_ERROR);
                 return response;
             }
-
-            cacheService.putCache(buildCacheKey("user:extendedProfile", contextType, userId), existingList);
+            redisDataService.putMapList(buildCacheKey("user:extendedProfileV2", contextType, userId), existingList);
             updateExtendedProfileAllCache(userId, contextType, existingList);
             savedDataWithUUIDs.addAll(dataWithUUIDs);
         }
@@ -178,10 +175,7 @@ public class ProfileServiceImpl implements ProfileService {
                     return response;
                 }
             }
-
             List<Map<String, Object>> mergedList = new ArrayList<>(dataMap.values());
-            //sortContextData(mergedList, contextType);
-
             if (Constants.ACHIEVEMENTS.equalsIgnoreCase(contextType)) {
                 mergeAndSortByIssuedDateOrTitle(mergedList, new ArrayList<>());
             }
@@ -190,8 +184,7 @@ public class ProfileServiceImpl implements ProfileService {
                         HttpStatus.INTERNAL_SERVER_ERROR);
                 return response;
             }
-
-            cacheService.putCache(buildCacheKey("user:extendedProfile", contextType, userId), mergedList);
+            redisDataService.putMapList(buildCacheKey("user:extendedProfileV2", contextType, userId), mergedList);
             updateExtendedProfileAllCache(userId, contextType, mergedList);
         }
 
@@ -224,15 +217,12 @@ public class ProfileServiceImpl implements ProfileService {
 
             List<Map<String, Object>> existingData = getExistingContextData(userId, contextType);
             existingData.removeIf(e -> uuids.contains(e.get(Constants.UUID)));
-            //sortContextData(existingData, contextType);
-
             if (!saveContextData(userId, contextType, existingData)) {
                 ProjectUtil.errorResponse(response, "Failed to delete data for contextType: " + contextType,
                         HttpStatus.INTERNAL_SERVER_ERROR);
                 return response;
             }
-
-            cacheService.putCache(buildCacheKey("user:extendedProfile", contextType, userId), existingData);
+            redisDataService.putMapList(buildCacheKey("user:extendedProfileV2", contextType, userId), existingData);
             updateExtendedProfileAllCache(userId, contextType, existingData);
         }
 
@@ -250,11 +240,10 @@ public class ProfileServiceImpl implements ProfileService {
             return response;
         }
 
-        String redisKey = buildCacheKey("user:extendedProfile", "all", userId);
+        String extendedProfileSummaryKey = buildCacheKey("user:extendedProfileV2", "all", userId);
         try {
-            String cachedJson = cacheService.getCache(redisKey);
-            if (cachedJson != null) {
-                Map<String, Object> cachedResult = mapper.readValue(cachedJson, Map.class);
+            Map<String, Object> cachedResult = redisDataService.getMap(extendedProfileSummaryKey);
+            if (MapUtils.isNotEmpty(cachedResult)) {
                 Map<String, Object> limitedResult = buildLimitedSummary(cachedResult);
                 response.setResponseCode(HttpStatus.OK);
                 response.put(Constants.RESPONSE, limitedResult);
@@ -282,7 +271,7 @@ public class ProfileServiceImpl implements ProfileService {
 
         result.put(Constants.USERID_KEY, userId);
         try {
-            cacheService.putCache(redisKey, result);
+            redisDataService.putMap(extendedProfileSummaryKey, result);
         } catch (Exception e) {
             log.warn("Failed to cache extended profile summary for userId {}: {}", userId, e.getMessage());
         }
@@ -302,28 +291,25 @@ public class ProfileServiceImpl implements ProfileService {
             return response;
         }
 
-        String redisKey = buildCacheKey("user:extendedProfile", contextType, userId);
+        String fullExtendedProfileKey = buildCacheKey("user:extendedProfileV2", contextType, userId);
         List<Map<String, Object>> contextData = null;
 
         try {
-            String cachedJson = cacheService.getCache(redisKey);
-            if (cachedJson != null) {
-                contextData = projectUtil.parseListOfMap(cachedJson);
-            }
+            contextData=redisDataService.getMapList(fullExtendedProfileKey);
         } catch (Exception e) {
-            log.warn("Error reading from cache for key {}: {}", redisKey, e.getMessage());
+            log.warn("Error reading from cache for key {}: {}", fullExtendedProfileKey, e.getMessage());
         }
 
-        if (contextData == null) {
+        if (CollectionUtils.isEmpty(contextData )) {
             contextData = getExistingContextData(userId, contextType);
             if (contextData == null || contextData.isEmpty()) {
                 ProjectUtil.errorResponse(response, "No data found for user.", HttpStatus.NO_CONTENT);
                 return response;
             }
             try {
-                cacheService.putCache(redisKey, contextData);
+                redisDataService.putMapList(fullExtendedProfileKey,contextData);
             } catch (Exception e) {
-                log.warn("Failed to cache data for key {}: {}", redisKey, e.getMessage());
+                log.warn("Failed to cache data for key {}: {}", fullExtendedProfileKey, e.getMessage());
             }
         }
 

--- a/src/main/java/com/igot/cb/profile/service/ProfileServiceImpl.java
+++ b/src/main/java/com/igot/cb/profile/service/ProfileServiceImpl.java
@@ -23,6 +23,7 @@ import java.util.stream.Stream;
 import com.igot.cb.common.OutboundRequestHandlerServiceImpl;
 import com.igot.cb.transactional.redis.cache.RedissonRedisDataService;
 import com.igot.cb.util.*;
+import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -98,7 +99,7 @@ public class ProfileServiceImpl implements ProfileService {
         String userIdFromToken = accessTokenValidator.fetchUserIdFromAccessToken(userToken);
 
         if (!StringUtils.equalsIgnoreCase(userIdFromToken, userId)) {
-            ProjectUtil.errorResponse(response, "Invalid UserId in the request", HttpStatus.BAD_REQUEST);
+            ProjectUtil.errorResponse(response, Constants.INVALID_USERID_IN_REQUEST, HttpStatus.BAD_REQUEST);
             return response;
         }
 
@@ -128,12 +129,12 @@ public class ProfileServiceImpl implements ProfileService {
             }else{
                 existingList.addAll(dataWithUUIDs);
             }
-            if (!saveContextData(userId, contextType, existingList)) {
+            if (saveContextData(userId, contextType, existingList)) {
                 ProjectUtil.errorResponse(response, "Failed to save data for contextType: " + contextType,
                         HttpStatus.INTERNAL_SERVER_ERROR);
                 return response;
             }
-            redisDataService.putMapList(buildCacheKey("user:extendedProfileV2", contextType, userId), existingList);
+            redisDataService.putMapList(buildCacheKey(contextType, userId), existingList);
             updateExtendedProfileAllCache(userId, contextType, existingList);
             savedDataWithUUIDs.addAll(dataWithUUIDs);
         }
@@ -151,7 +152,7 @@ public class ProfileServiceImpl implements ProfileService {
         String userIdFromToken = accessTokenValidator.fetchUserIdFromAccessToken(userToken);
 
         if (!StringUtils.equalsIgnoreCase(userIdFromToken, userId)) {
-            ProjectUtil.errorResponse(response, "Invalid UserId in the request", HttpStatus.BAD_REQUEST);
+            ProjectUtil.errorResponse(response, Constants.INVALID_USERID_IN_REQUEST, HttpStatus.BAD_REQUEST);
             return response;
         }
 
@@ -179,12 +180,12 @@ public class ProfileServiceImpl implements ProfileService {
             if (Constants.ACHIEVEMENTS.equalsIgnoreCase(contextType)) {
                 mergeAndSortByIssuedDateOrTitle(mergedList, new ArrayList<>());
             }
-            if (!saveContextData(userId, contextType, mergedList)) {
+            if (saveContextData(userId, contextType, mergedList)) {
                 ProjectUtil.errorResponse(response, "Failed to update data for contextType: " + contextType,
                         HttpStatus.INTERNAL_SERVER_ERROR);
                 return response;
             }
-            redisDataService.putMapList(buildCacheKey("user:extendedProfileV2", contextType, userId), mergedList);
+            redisDataService.putMapList(buildCacheKey(contextType, userId), mergedList);
             updateExtendedProfileAllCache(userId, contextType, mergedList);
         }
 
@@ -201,7 +202,7 @@ public class ProfileServiceImpl implements ProfileService {
         String userIdFromToken = accessTokenValidator.fetchUserIdFromAccessToken(userToken);
 
         if (!StringUtils.equalsIgnoreCase(userIdFromToken, userId)) {
-            ProjectUtil.errorResponse(response, "Invalid UserId in the request", HttpStatus.BAD_REQUEST);
+            ProjectUtil.errorResponse(response, Constants.INVALID_USERID_IN_REQUEST, HttpStatus.BAD_REQUEST);
             return response;
         }
 
@@ -216,13 +217,13 @@ public class ProfileServiceImpl implements ProfileService {
                     .collect(Collectors.toSet());
 
             List<Map<String, Object>> existingData = getExistingContextData(userId, contextType);
-            existingData.removeIf(e -> uuids.contains(e.get(Constants.UUID)));
-            if (!saveContextData(userId, contextType, existingData)) {
+            existingData.removeIf(e -> uuids.contains(String.valueOf(e.get(Constants.UUID))));
+            if (saveContextData(userId, contextType, existingData)) {
                 ProjectUtil.errorResponse(response, "Failed to delete data for contextType: " + contextType,
                         HttpStatus.INTERNAL_SERVER_ERROR);
                 return response;
             }
-            redisDataService.putMapList(buildCacheKey("user:extendedProfileV2", contextType, userId), existingData);
+            redisDataService.putMapList(buildCacheKey(contextType, userId), existingData);
             updateExtendedProfileAllCache(userId, contextType, existingData);
         }
 
@@ -236,11 +237,11 @@ public class ProfileServiceImpl implements ProfileService {
         ApiResponse response = ProjectUtil.createDefaultResponse("api.extendedProfile.read");
 
         if (accessTokenValidator.fetchUserIdFromAccessToken(userToken) == null) {
-            ProjectUtil.errorResponse(response, "Invalid UserId in the request", HttpStatus.BAD_REQUEST);
+            ProjectUtil.errorResponse(response, Constants.INVALID_USERID_IN_REQUEST, HttpStatus.BAD_REQUEST);
             return response;
         }
 
-        String extendedProfileSummaryKey = buildCacheKey("user:extendedProfileV2", "all", userId);
+        String extendedProfileSummaryKey = buildCacheKey("all", userId);
         try {
             Map<String, Object> cachedResult = redisDataService.getMap(extendedProfileSummaryKey);
             if (MapUtils.isNotEmpty(cachedResult)) {
@@ -259,7 +260,7 @@ public class ProfileServiceImpl implements ProfileService {
             if (!data.isEmpty()) {
                 Map<String, Object> contextSummary = new HashMap<>();
                 contextSummary.put(Constants.COUNT, data.size());
-                contextSummary.put(Constants.DATA, data.stream().limit(2).collect(Collectors.toList()));
+                contextSummary.put(Constants.DATA, data.stream().limit(2).toList());
                 result.put(contextType, contextSummary);
             }
         }
@@ -287,11 +288,11 @@ public class ProfileServiceImpl implements ProfileService {
         String userIdFromToken = accessTokenValidator.fetchUserIdFromAccessToken(userToken);
 
         if (StringUtils.isEmpty(userIdFromToken)) {
-            ProjectUtil.errorResponse(response, "Invalid UserId in the request", HttpStatus.BAD_REQUEST);
+            ProjectUtil.errorResponse(response, Constants.INVALID_USERID_IN_REQUEST, HttpStatus.BAD_REQUEST);
             return response;
         }
 
-        String fullExtendedProfileKey = buildCacheKey("user:extendedProfileV2", contextType, userId);
+        String fullExtendedProfileKey = buildCacheKey(contextType, userId);
         List<Map<String, Object>> contextData = null;
 
         try {
@@ -330,7 +331,7 @@ public class ProfileServiceImpl implements ProfileService {
         String userIdFromToken = accessTokenValidator.fetchUserIdFromAccessToken(userToken);
 
         if (StringUtils.isEmpty(userIdFromToken)) {
-            ProjectUtil.errorResponse(response, "Invalid or missing access token", HttpStatus.UNAUTHORIZED);
+            ProjectUtil.errorResponse(response, Constants.INVALID_OR_MISSING_ACCESS_TOKEN, HttpStatus.UNAUTHORIZED);
             return response;
         }
 
@@ -386,7 +387,7 @@ public class ProfileServiceImpl implements ProfileService {
         String userIdFromToken = accessTokenValidator.fetchUserIdFromAccessToken(userToken);
 
         if (userIdFromToken == null) {
-            ProjectUtil.errorResponse(response, "Invalid or missing access token", HttpStatus.UNAUTHORIZED);
+            ProjectUtil.errorResponse(response, Constants.INVALID_OR_MISSING_ACCESS_TOKEN, HttpStatus.UNAUTHORIZED);
             return response;
         }
 
@@ -407,7 +408,7 @@ public class ProfileServiceImpl implements ProfileService {
                         .map(map -> map.get(Constants.COURSE_ID))
                         .filter(Objects::nonNull)
                         .map(Object::toString)
-                        .collect(Collectors.toList());
+                        .toList();
                 if (completedCourseIdList.isEmpty()) {
                     ProjectUtil.errorResponse(response, "No competencies found for user.", HttpStatus.NO_CONTENT);
                     return response;
@@ -466,34 +467,16 @@ public class ProfileServiceImpl implements ProfileService {
             query.put(Constants.CONTEXT_DATA, finalJson);
             ApiResponse insertResponse = (ApiResponse) cassandraOperation.insertRecord(Constants.KEYSPACE_SUNBIRD,
                     Constants.TABLE_USER_EXTENDED_PROFILE, query);
-            return Constants.SUCCESS.equalsIgnoreCase((String) insertResponse.get(Constants.RESPONSE));
+            return !Constants.SUCCESS.equalsIgnoreCase((String) insertResponse.get(Constants.RESPONSE));
         } catch (JsonProcessingException e) {
             log.error("Failed to serialize context data for userId: {}, contextType: {}", userId, contextType);
         }
-        return false;
+        return true;
     }
 
-    private void sortContextData(List<Map<String, Object>> dataList, String contextType) {
-        Comparator<Map<String, Object>> comparator = getSortingComparator(contextType);
-        if (comparator != null) {
-            dataList.sort(comparator.reversed());
-        }
-    }
 
-    private Comparator<Map<String, Object>> getSortingComparator(String contextType) {
-        return switch (contextType) {
-            case Constants.SERVICE_HISTORY ->
-                Comparator.comparing(map -> OffsetDateTime.parse((String) map.get(Constants.START_DATE)));
-            case Constants.EDUCATIONAL_QUALIFICATIONS ->
-                Comparator.comparing(map -> Integer.parseInt((String) map.get(Constants.START_YEAR)));
-            case Constants.ACHIVEMENTS ->
-                Comparator.comparing(map -> OffsetDateTime.parse((String) map.get(Constants.ISSUED_DATE)));
-            default -> null;
-        };
-    }
-
-    private String buildCacheKey(String prefix, String contextType, String userId) {
-        return String.join(":", prefix, contextType, userId);
+    private String buildCacheKey(String contextType, String userId) {
+        return String.join(":", Constants.USER_EXTENDED_PROFILE_V2_REDIS_KEY, contextType, userId);
     }
 
     private void updateExtendedProfileAllCache(String userId, String contextType,
@@ -615,32 +598,22 @@ public class ProfileServiceImpl implements ProfileService {
         }
     }
 
+    /**
+     * Checks the user's connection status by calling an external service and parsing the response.
+     * Builds the required headers, fetches connection data, and extracts the response into a map.
+     *
+     * @param userId        the ID of the user to check
+     * @param authToken     authentication token
+     * @param userAuthToken authentication token
+     * @return a map containing the extracted connection details; empty if no data is found
+     */
     public Map<String, Object> checkConnected(String userId, String authToken, String userAuthToken) {
-        Map<String, String> header = new HashMap<>();
-        if (StringUtils.isNotEmpty(authToken)) {
-            header.put(Constants.AUTH_TOKEN, authToken);
-        }
-        if (StringUtils.isNotEmpty(userAuthToken)) {
-            header.put(Constants.X_AUTH_TOKEN, userAuthToken);
-        }
+        Map<String, String> header = buildHeaders(authToken, userAuthToken);
         Map<String, Object> responseMap = new HashMap<>();
-        Map<String, Object> readData = (Map<String, Object>) outboundRequestHandlerService
-                .fetchUsingGetWithHeadersProfile(serverConfig.hubGraphService + serverConfig.connectionApi + userId,
-                        header);
-        if (readData != null) {
-            Object resultObj = readData.get(Constants.RESULT);
-            if (resultObj instanceof Map<?, ?> resultMap) {
-                Object responseObj = resultMap.get(Constants.RESPONSE);
-                if (responseObj instanceof Map<?, ?> responseData) {
-                    for (Map.Entry<?, ?> entry : responseData.entrySet()) {
-                        if (entry.getKey() instanceof String) {
-                            responseMap.put((String) entry.getKey(), entry.getValue());
-                        }
-                    }
-                }
-            }
+        Map<String, Object> readData = fetchConnectionData(userId, header);
+        if (MapUtils.isNotEmpty(readData)) {
+            extractResponseData(readData, responseMap);
         }
-
         return responseMap;
     }
 
@@ -1037,7 +1010,7 @@ public class ProfileServiceImpl implements ProfileService {
         String userIdFromToken = accessTokenValidator.fetchUserIdFromAccessToken(authToken);
 
         if (StringUtils.isBlank(authToken)) {
-            ProjectUtil.errorResponse(response, "Invalid or missing access token", HttpStatus.UNAUTHORIZED);
+            ProjectUtil.errorResponse(response, Constants.INVALID_OR_MISSING_ACCESS_TOKEN, HttpStatus.UNAUTHORIZED);
             return response;
         }
 
@@ -1063,7 +1036,7 @@ public class ProfileServiceImpl implements ProfileService {
 
             List<Map<String, Object>> restructuredData = restructureByOrgId(existingData, organisationId, customFieldValues);
 
-            if (!saveContextData(userId, contextType, restructuredData)) {
+            if (saveContextData(userId, contextType, restructuredData)) {
                 ProjectUtil.errorResponse(response, "Failed to save additional fields", HttpStatus.INTERNAL_SERVER_ERROR);
                 return response;
             }
@@ -1334,7 +1307,7 @@ public class ProfileServiceImpl implements ProfileService {
         String userIdFromToken = accessTokenValidator.fetchUserIdFromAccessToken(authToken);
 
         if (StringUtils.isBlank(authToken)) {
-            ProjectUtil.errorResponse(response, "Invalid or missing access token", HttpStatus.UNAUTHORIZED);
+            ProjectUtil.errorResponse(response, Constants.INVALID_OR_MISSING_ACCESS_TOKEN, HttpStatus.UNAUTHORIZED);
             return response;
         }
 
@@ -1513,5 +1486,58 @@ public class ProfileServiceImpl implements ProfileService {
         if (connectionResponse == null) return false;
         Object statusObj = connectionResponse.get(Constants.STATUS);
         return statusObj != null && Constants.APPROVED.equalsIgnoreCase(statusObj.toString());
+    }
+
+
+    /**
+     * Builds and returns a map of authorization headers using the provided tokens.
+     * Adds entries only if the tokens are not empty.
+     *
+     * @param authToken     auth token
+     * @param userAuthToken auth token
+     * @return map of HTTP headers
+     */
+    private Map<String, String> buildHeaders(String authToken, String userAuthToken) {
+        Map<String, String> headers = new HashMap<>();
+        if (StringUtils.isNotEmpty(authToken)) {
+            headers.put(Constants.AUTH_TOKEN, authToken);
+        }
+        if (StringUtils.isNotEmpty(userAuthToken)) {
+            headers.put(Constants.X_AUTH_TOKEN, userAuthToken);
+        }
+        return headers;
+    }
+
+    /**
+     * Fetches connection data for the given user from the external service using the provided headers.
+     *
+     * @param userId the ID of the user whose connection data is to be fetched
+     * @param header the HTTP headers to include in the request
+     * @return the connection data as a map, or null if no data is returned
+     */
+    private Map<String, Object> fetchConnectionData(String userId, Map<String, String> header) {
+        return (Map<String, Object>) outboundRequestHandlerService
+                .fetchUsingGetWithHeadersProfile(serverConfig.hubGraphService + serverConfig.connectionApi + userId,
+                        header);
+    }
+
+    /**
+     * Extracts response data from the given read data map and populates it into the provided response map.
+     *
+     * @param readData    the raw data map containing nested response information
+     * @param responseMap the map to populate with extracted response entries
+     */
+    private static void extractResponseData(Map<String, Object> readData, Map<String, Object> responseMap) {
+        Object resultObj = readData.get(Constants.RESULT);
+        if (resultObj instanceof Map<?, ?> resultMap) {
+            Object responseObj = resultMap.get(Constants.RESPONSE);
+            if (responseObj instanceof Map<?, ?> responseData) {
+                for (Map.Entry<?, ?> entry : responseData.entrySet()) {
+                    if (entry.getKey() instanceof String) {
+                        responseMap.put((String) entry.getKey(), entry.getValue());
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/main/java/com/igot/cb/profile/service/ProfileServiceImpl.java
+++ b/src/main/java/com/igot/cb/profile/service/ProfileServiceImpl.java
@@ -481,18 +481,14 @@ public class ProfileServiceImpl implements ProfileService {
 
     private void updateExtendedProfileAllCache(String userId, String contextType,
             List<Map<String, Object>> updatedContextData) {
-        String allKey = "user:extendedProfile:all:" + userId;
+        String allKey = "user:extendedProfileV2:all:" + userId;
         try {
-            String allJson = cacheService.getCache(allKey);
-            Map<String, Object> allProfileData = (allJson != null && !allJson.isEmpty())
-                    ? mapper.readValue(allJson, new TypeReference<>() {
-                    })
-                    : new HashMap<>();
+            Map<String, Object> allProfileData =redisDataService.getMap(allKey);
             Map<String, Object> updatedContext = new HashMap<>();
             updatedContext.put(Constants.DATA, updatedContextData);
             updatedContext.put(Constants.COUNT, updatedContextData != null ? updatedContextData.size() : 0);
             allProfileData.put(contextType, updatedContext);
-            cacheService.putCache(allKey, allProfileData);
+            redisDataService.putMap(allKey, allProfileData);
         } catch (Exception e) {
             log.error("Error updating extendedProfile all cache for userId {}: {}", userId, e.getMessage());
         }

--- a/src/main/java/com/igot/cb/transactional/redis/cache/RedissonRedisDataService.java
+++ b/src/main/java/com/igot/cb/transactional/redis/cache/RedissonRedisDataService.java
@@ -1,10 +1,15 @@
 package com.igot.cb.transactional.redis.cache;
 
+import com.igot.cb.masterdata.service.MasterDataServiceImpl;
 import com.igot.cb.util.CbServerProperties;
+import org.apache.commons.collections4.CollectionUtils;
 import org.redisson.api.RList;
 import org.redisson.api.RType;
 import org.redisson.api.RedissonClient;
 import org.redisson.api.RMap;
+import org.redisson.codec.JsonJacksonCodec;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.util.Collections;
@@ -37,7 +42,7 @@ public class RedissonRedisDataService {
         }
         RMap<String, Object> map = redissonClient.getMap(redisKey);
         map.putAll(data);
-        redissonClient.getKeys().expire(redisKey, cbServerProperties.getUserProfileKeysTtl(), TimeUnit.MILLISECONDS);
+        redissonClient.getKeys().expire(redisKey, cbServerProperties.getUserProfileKeysTtl(), TimeUnit.SECONDS);
     }
 
 
@@ -58,11 +63,33 @@ public class RedissonRedisDataService {
         RList<String> redisList = redissonClient.getList(redisKey);
         redisList.clear();
         redisList.addAll(list);
-        redissonClient.getKeys().expire(redisKey, cbServerProperties.getUserProfileKeysTtl(), TimeUnit.MILLISECONDS);
+        redissonClient.getKeys().expire(redisKey, cbServerProperties.getUserProfileKeysTtl(), TimeUnit.SECONDS);
     }
 
     public List<String> getStringList(String redisKey) {
         RList<String> redisList = redissonClient.getList(redisKey);
+        if (redisList == null || redisList.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return redisList.readAll();
+    }
+
+    public void putMapList(String redisKey, List<Map<String, Object>> list) {
+        if (CollectionUtils.isEmpty(list)) {
+            return;
+        }
+        RType type = redissonClient.getKeys().getType(redisKey);
+        if (type != null && !"list".equalsIgnoreCase(type.name()) && !"none".equalsIgnoreCase(type.name())) {
+            redissonClient.getKeys().delete(redisKey);
+        }
+        RList<Map<String, Object>> redisList = redissonClient.getList(redisKey);
+        redisList.clear();
+        redisList.addAll(list);
+        redissonClient.getKeys().expire(redisKey, cbServerProperties.getUserProfileKeysTtl(), TimeUnit.SECONDS);
+    }
+
+    public List<Map<String, Object>> getMapList(String redisKey) {
+        RList<Map<String, Object>> redisList = redissonClient.getList(redisKey);
         if (redisList == null || redisList.isEmpty()) {
             return Collections.emptyList();
         }

--- a/src/main/java/com/igot/cb/transactional/redis/cache/RedissonRedisDataService.java
+++ b/src/main/java/com/igot/cb/transactional/redis/cache/RedissonRedisDataService.java
@@ -1,0 +1,71 @@
+package com.igot.cb.transactional.redis.cache;
+
+import com.igot.cb.util.CbServerProperties;
+import org.redisson.api.RList;
+import org.redisson.api.RType;
+import org.redisson.api.RedissonClient;
+import org.redisson.api.RMap;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+@Service
+public class RedissonRedisDataService {
+
+    private final RedissonClient redissonClient;
+
+    private final CbServerProperties cbServerProperties;
+
+    public RedissonRedisDataService(RedissonClient redissonClient, CbServerProperties cbServerProperties) {
+        this.redissonClient = redissonClient;
+        this.cbServerProperties = cbServerProperties;
+    }
+
+    public void putMap(String redisKey, Map<String, Object> data) {
+        if (data == null || data.isEmpty()) {
+            return;
+        }
+        RType type = redissonClient.getKeys().getType(redisKey);
+        if (type != null
+                && !"hash".equalsIgnoreCase(type.name())
+                && !"map".equalsIgnoreCase(type.name())
+                && !"none".equalsIgnoreCase(type.name())) {
+            redissonClient.getKeys().delete(redisKey);
+        }
+        RMap<String, Object> map = redissonClient.getMap(redisKey);
+        map.putAll(data);
+        redissonClient.getKeys().expire(redisKey, cbServerProperties.getUserProfileKeysTtl(), TimeUnit.MILLISECONDS);
+    }
+
+
+    public Map<String, Object> getMap(String redisKey) {
+        RMap<String, Object> map = redissonClient.getMap(redisKey);
+        return map.readAllMap();
+    }
+
+
+    public void putStringList(String redisKey, List<String> list) {
+        if (list == null || list.isEmpty()) {
+            return;
+        }
+        RType type = redissonClient.getKeys().getType(redisKey);
+        if (type != null && !"list".equalsIgnoreCase(type.name()) && !"none".equalsIgnoreCase(type.name())) {
+            redissonClient.getKeys().delete(redisKey);
+        }
+        RList<String> redisList = redissonClient.getList(redisKey);
+        redisList.clear();
+        redisList.addAll(list);
+        redissonClient.getKeys().expire(redisKey, cbServerProperties.getUserProfileKeysTtl(), TimeUnit.MILLISECONDS);
+    }
+
+    public List<String> getStringList(String redisKey) {
+        RList<String> redisList = redissonClient.getList(redisKey);
+        if (redisList == null || redisList.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return redisList.readAll();
+    }
+}

--- a/src/main/java/com/igot/cb/transactional/redis/config/RedissonRedisConfig.java
+++ b/src/main/java/com/igot/cb/transactional/redis/config/RedissonRedisConfig.java
@@ -1,0 +1,58 @@
+package com.igot.cb.transactional.redis.config;
+
+import com.igot.cb.util.CbServerProperties;
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class RedissonRedisConfig {
+
+    private final CbServerProperties cbProperties;
+
+    public RedissonRedisConfig(CbServerProperties cbProperties) {
+        this.cbProperties = cbProperties;
+    }
+
+    @Bean(destroyMethod = "shutdown", name = "redissonClient")
+    @Primary
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer()
+                .setAddress("redis://" + cbProperties.getRedisHostName() + ":" + cbProperties.getRedisPort())
+                .setConnectionPoolSize(cbProperties.getRedisMaxTotal())
+                .setConnectionMinimumIdleSize(cbProperties.getRedisMinIdle())
+                .setIdleConnectionTimeout(cbProperties.getIdleConnectionTimeout())
+                .setConnectTimeout(cbProperties.getConnectTimeout())
+                .setTimeout(cbProperties.getTimeout())
+                .setRetryAttempts(cbProperties.getRetryAttempts())
+                .setRetryInterval(cbProperties.getRetryInterval())
+                .setPingConnectionInterval(cbProperties.getPingConnectionInterval())
+                .setKeepAlive(cbProperties.isKeepAlive())
+                .setTcpNoDelay(cbProperties.isTcpNoDelay());
+
+        return Redisson.create(config);
+    }
+
+    @Bean(destroyMethod = "shutdown", name = "redissonDataPopulationClient")
+    public RedissonClient redissonDataPopulationClient() {
+        Config config = new Config();
+        config.useSingleServer()
+                .setAddress("redis://" + cbProperties.getRedisDataHostName() + ":" + cbProperties.getRedisDataPort())
+                .setConnectionPoolSize(cbProperties.getRedisMaxTotal())
+                .setConnectionMinimumIdleSize(cbProperties.getRedisMinIdle())
+                .setIdleConnectionTimeout(cbProperties.getIdleConnectionTimeout())
+                .setConnectTimeout(cbProperties.getConnectTimeout())
+                .setTimeout(cbProperties.getTimeout())
+                .setRetryAttempts(cbProperties.getRetryAttempts())
+                .setRetryInterval(cbProperties.getRetryInterval())
+                .setPingConnectionInterval(cbProperties.getPingConnectionInterval())
+                .setKeepAlive(cbProperties.isKeepAlive())
+                .setTcpNoDelay(cbProperties.isTcpNoDelay());
+
+        return Redisson.create(config);
+    }
+}

--- a/src/main/java/com/igot/cb/util/CbServerProperties.java
+++ b/src/main/java/com/igot/cb/util/CbServerProperties.java
@@ -149,4 +149,32 @@ public class CbServerProperties {
 
     @Value("${db.table.user-enrolments}")
     private String userEnrolmentsTable;
+
+    @Value("${user.profile.keys.ttl}")
+    private int userProfileKeysTtl;
+
+    @Value("${redisson.idleConnectionTimeout}")
+    private int idleConnectionTimeout;
+
+    @Value("${redisson.connectTimeout}")
+    private int connectTimeout;
+
+    @Value("${redisson.timeout}")
+    private int timeout;
+
+    @Value("${redisson.retryAttempts}")
+    private int retryAttempts;
+
+    @Value("${redisson.retryInterval}")
+    private int retryInterval;
+
+    @Value("${redisson.pingConnectionInterval}")
+    private int pingConnectionInterval;
+
+    @Value("${redisson.keepAlive}")
+    private boolean keepAlive;
+
+    @Value("${redisson.tcpNoDelay}")
+    private boolean tcpNoDelay;
+
 }

--- a/src/main/java/com/igot/cb/util/Constants.java
+++ b/src/main/java/com/igot/cb/util/Constants.java
@@ -456,6 +456,9 @@ public class Constants {
     public static final String AUTH_TOKEN = "Authorization";
     public static final String APPROVED = "Approved";
     public static final String USER_EXTERNAL_COURSE_ENROLMENTS = "user_external_enrolments";
+    public static final String INVALID_USERID_IN_REQUEST="Invalid UserId in the request";
+    public static final String USER_EXTENDED_PROFILE_V2_REDIS_KEY="user:extendedProfileV2";
+    public static final String INVALID_OR_MISSING_ACCESS_TOKEN="Invalid or missing access token";
     private Constants() {
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -99,8 +99,8 @@ validation.required-fields.educationalQualification=degree,institutionName,start
 validation.required-fields.achievement=title,issuedOrganisation,issuedDate
 validation.required-fields.serviceHistory=orgName,designation,orgState,orgDistrict,startDate,endDate,currentlyWorking
 context.types=educationalQualifications,achievements,serviceHistory
-basic.profile.fields=id,channel,firstName,profiledetails,rootOrgId,username
-profile.completion.required.fields=firstName,profileImageUrl,locationDetails,profileBannerUrl,serviceHistory,educationalQualifications
+basic.profile.fields=id,channel,firstName,profileDetails,rootOrgId,username
+profile.completion.required.fields=employmentDetails,profileImageUrl,locationDetails,profileBannerUrl,serviceHistory,educationalQualifications
 profile.completion.extended.fields=serviceHistory,educationalQualifications,locationDetails
 profile.completion.field.weight=16.7
 community.base.url=http://discussion-metaupdate-service:7002
@@ -140,5 +140,16 @@ profile.visible.allowed.fields=profileImageUrl,profileStatus,employmentDetails, 
 user.basic.details.filtered=profileCompletionPercentage,karmaPoints,certificateCount,postCount
 db.table.user-enrolments=user_enrolments_v2
 
+user.profile.keys.ttl=86400
 
+#redisson configurations
+user.profile.keys.ttl=3600
+redisson.idleConnectionTimeout=10000
+redisson.connectTimeout=10000
+redisson.timeout=10000
+redisson.retryAttempts=5
+redisson.retryInterval=1500
+redisson.pingConnectionInterval=30000
+redisson.keepAlive=true
+redisson.tcpNoDelay=true
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -143,7 +143,6 @@ db.table.user-enrolments=user_enrolments_v2
 user.profile.keys.ttl=86400
 
 #redisson configurations
-user.profile.keys.ttl=3600
 redisson.idleConnectionTimeout=10000
 redisson.connectTimeout=10000
 redisson.timeout=10000

--- a/src/test/java/com/igot/cb/profile/ProfileServiceImpl2Test.java
+++ b/src/test/java/com/igot/cb/profile/ProfileServiceImpl2Test.java
@@ -3,6 +3,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.igot.cb.profile.service.ProfileServiceImpl;
 import com.igot.cb.transactional.cassandrautils.CassandraOperation;
+import com.igot.cb.transactional.redis.cache.RedissonRedisDataService;
 import com.igot.cb.util.Constants;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -37,9 +38,12 @@ class ProfileServiceImpl2Test {
     private final String userId = "user123";
     private final String rootOrgId = "org001";
 
+    @Mock
+    private RedissonRedisDataService redisDataService;
+
     @BeforeEach
     void setUp() {
-        // Setup done by MockitoExtension
+        redisDataService = mock(RedissonRedisDataService.class);
     }
 
     @Test

--- a/src/test/java/com/igot/cb/profile/ProfileServiceImplPrivateMethodTest.java
+++ b/src/test/java/com/igot/cb/profile/ProfileServiceImplPrivateMethodTest.java
@@ -5,9 +5,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.igot.cb.authentication.util.AccessTokenValidator;
 import com.igot.cb.profile.service.ProfileServiceImpl;
 import com.igot.cb.transactional.redis.cache.CacheService;
-import com.igot.cb.util.ApiResponse;
-import com.igot.cb.util.CbServerProperties;
-import com.igot.cb.util.UserUtility;
+import com.igot.cb.transactional.redis.cache.RedissonRedisDataService;
+import com.igot.cb.util.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,8 +22,7 @@ import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class ProfileServiceImplPrivateMethodTest {
@@ -40,6 +38,9 @@ class ProfileServiceImplPrivateMethodTest {
     private ObjectMapper mapper;
     @Mock
     private CbServerProperties serverConfig;
+
+    @Mock
+    private RedissonRedisDataService redisDataService;
 
     @BeforeEach
     void setup() {
@@ -61,29 +62,20 @@ class ProfileServiceImplPrivateMethodTest {
     void testGetBasicProfile_CacheHitWithDifferenceList() throws Exception {
         String userId = "user123";
         String userToken = "token123";
-
+        RedissonRedisDataService redisDataService = mock(RedissonRedisDataService.class);
         when(accessTokenValidator.fetchUserIdFromAccessToken(userToken)).thenReturn(userId);
-
-        // Simulate cache hit with some missing fields
         Map<String, Object> cachedMap = new HashMap<>();
         cachedMap.put("field1", "value1");
         String cachedJson = "{\"field1\":\"value1\"}";
-
         when(cacheService.getCache(anyString())).thenReturn(cachedJson);
         when(mapper.readValue(eq(cachedJson), any(TypeReference.class))).thenReturn(cachedMap);
-
-        // Server config requires more fields
         when(serverConfig.getBasicProfileFields()).thenReturn(Arrays.asList("field1", "field2"));
-
-        // Mock DB call for missing field
         Map<String, Object> dbData = Map.of("field2", "value2");
         ProfileServiceImpl spyService = Mockito.spy(profileService);
+        ReflectionTestUtils.setField(spyService, "redisDataService", redisDataService);
         doReturn(dbData).when(spyService).readUserDataFromDB(eq(userId), anyList());
-
-        // Mock static methods
         try (MockedStatic<UserUtility> mockedUtility = Mockito.mockStatic(UserUtility.class)) {
             mockedUtility.when(() -> UserUtility.decryptSpecificUserData(anyMap(), anyList())).then(inv -> null);
-
             ApiResponse response = spyService.getBasicProfile(userId, userToken);
             assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getResponseCode());
         }
@@ -93,15 +85,13 @@ class ProfileServiceImplPrivateMethodTest {
     void testGetBasicProfile_NoCache_EmptyUserProfile() {
         String userId = "user123";
         String userToken = "token123";
-
         when(accessTokenValidator.fetchUserIdFromAccessToken(userToken)).thenReturn(userId);
-        when(cacheService.getCache(anyString())).thenReturn(null);
-
+        lenient().when(cacheService.getCache(anyString())).thenReturn(null);
         ProfileServiceImpl spyService = Mockito.spy(profileService);
         doReturn(Collections.emptyMap()).when(spyService).readUserDataFromDB(eq(userId), isNull());
-
         try (MockedStatic<UserUtility> mockedUtility = Mockito.mockStatic(UserUtility.class)) {
-            mockedUtility.when(() -> UserUtility.decryptSpecificUserData(anyMap(), anyList())).then(inv -> null);
+            mockedUtility.when(() -> UserUtility.decryptSpecificUserData(anyMap(), anyList()))
+                    .then(inv -> null);
             ApiResponse response = spyService.getBasicProfile(userId, userToken);
             assertEquals(HttpStatus.NOT_FOUND, response.getResponseCode());
         }
@@ -111,29 +101,25 @@ class ProfileServiceImplPrivateMethodTest {
     void testGetBasicProfile_NonSelfUser_CallsSanitize() {
         String userId = "user123";
         String userToken = "token123";
-
         when(accessTokenValidator.fetchUserIdFromAccessToken(userToken)).thenReturn("otherUser");
         when(cacheService.getCache(anyString())).thenReturn(null);
-
-        ProfileServiceImpl spyService = Mockito.spy(profileService);
         Map<String, Object> profileMap = new HashMap<>();
         profileMap.put("field1", "value1");
-
-        doReturn(profileMap).when(spyService).readUserDataFromDB(eq(userId), isNull());
-
+        when(redisDataService.getMap(anyString())).thenReturn(profileMap);
         try (MockedStatic<UserUtility> mockedUtility = Mockito.mockStatic(UserUtility.class)) {
-            mockedUtility.when(() -> UserUtility.decryptSpecificUserData(anyMap(), anyList())).then(inv -> null);
-
-            ApiResponse response = spyService.getBasicProfile(userId, userToken);
+            mockedUtility.when(() -> UserUtility.decryptSpecificUserData(anyMap(), anyList()))
+                    .then(inv -> null);
+            ApiResponse response = profileService.getBasicProfile(userId, userToken);
             assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getResponseCode());
         }
     }
 
     @Test
     void testGetBasicProfile_Exception() {
-        when(accessTokenValidator.fetchUserIdFromAccessToken(anyString())).thenReturn("user123");
-        when(cacheService.getCache(anyString())).thenThrow(new RuntimeException("Cache failure"));
-
+        when(accessTokenValidator.fetchUserIdFromAccessToken(anyString()))
+                .thenReturn("user123");
+        lenient().when(cacheService.getCache(anyString()))
+                .thenThrow(new RuntimeException("Cache failure"));
         ApiResponse response = profileService.getBasicProfile("user123", "token123");
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getResponseCode());
     }

--- a/src/test/java/com/igot/cb/profile/ProfileServiceImplTest.java
+++ b/src/test/java/com/igot/cb/profile/ProfileServiceImplTest.java
@@ -61,6 +61,9 @@ class ProfileServiceImplTest {
     @Mock
     private EsUtilServiceImpl esUtilService;
 
+    @Mock
+    private RedissonRedisDataService redisDataService;
+
     private final String userID = "user-123";
     private final String token = "dummy-token";
     private static final String CACHE_KEY = "user:competencies:user123";
@@ -140,9 +143,7 @@ class ProfileServiceImplTest {
      void testGetExtendedProfileSummary_noCache_fallsBackToDB() throws Exception {
         String[] contextTypes = { "education" };
         List<Map<String, Object>> dataList = List.of(Map.of("field", "value"));
-
         when(accessTokenValidator.fetchUserIdFromAccessToken(token)).thenReturn(userID);
-        when(cacheService.getCache(anyString())).thenReturn(null);
         when(serverProperties.getContextType()).thenReturn(contextTypes);
         when(cassandraOperation.getRecordsByPropertiesByKey(anyString(), anyString(), anyMap(), isNull(), isNull()))
                 .thenReturn(List.of(Map.of(Constants.CONTEXT_DATA, "[{\"field\":\"value\"}]")));
@@ -246,16 +247,12 @@ class ProfileServiceImplTest {
     }
 
     @Test
-     void testReadFullExtendedProfile_fromCache_success() throws Exception {
+     void testReadFullExtendedProfile_fromCache_success() {
         String localContextType = "education";
         List<Map<String, Object>> data = List.of(Map.of("degree", "MSc"));
-
         when(accessTokenValidator.fetchUserIdFromAccessToken(token)).thenReturn(userID);
-        when(cacheService.getCache(anyString())).thenReturn("[{'degree':'MSc'}]");
-        when(projectUtil.parseListOfMap(anyString())).thenReturn(data);
-
+        when(redisDataService.getMapList(anyString())).thenReturn(data);
         ApiResponse response = profileService.readFullExtendedProfile(userID, localContextType, token);
-
         assertEquals(HttpStatus.OK, response.getResponseCode());
         assertNotNull(response.get(Constants.RESPONSE));
     }
@@ -365,44 +362,38 @@ class ProfileServiceImplTest {
     }
 
     @Test
-    void testExtendedProfile_cacheHit() throws Exception {
-        when(accessTokenValidator.fetchUserIdFromAccessToken(token)).thenReturn(userID);
-        String cachedJson = "{\"contextA\":{\"count\":3,\"data\":[{\"a\":1},{\"b\":2},{\"c\":3}]}}";
-
-        String redisKey = "user:extendedProfile:all:user-123"; // Correct key
-        when(cacheService.getCache(redisKey)).thenReturn(cachedJson);
-
-        Map<String, Object> fullMap = Map.of("contextA", Map.of(
-                "count", 3,
-                "data", List.of(
-                        Map.of("a", 1),
-                        Map.of("b", 2),
-                        Map.of("c", 3)
+    void testExtendedProfile_cacheHit() {
+        String userId = "user-123";
+        String userToken = "valid-token";
+        when(accessTokenValidator.fetchUserIdFromAccessToken(userToken)).thenReturn(userId);
+        String redisKey = "user:extendedProfileV2:all:" + userId;
+        Map<String, Object> cachedMap = Map.of(
+                "contextA", Map.of(
+                        "count", 3,
+                        "data", List.of(
+                                Map.of("a", 1),
+                                Map.of("b", 2),
+                                Map.of("c", 3)
+                        )
                 )
-        ));
-        when(objectMapper.readValue(cachedJson, Map.class)).thenReturn(fullMap);
-
-        ApiResponse response = profileService.getExtendedProfileSummary(userID, token);
-
+        );
+        when(redisDataService.getMap(redisKey)).thenReturn(cachedMap);
+        ApiResponse response = profileService.getExtendedProfileSummary(userId, userToken);
         assertEquals(HttpStatus.OK, response.getResponseCode());
         assertNotNull(response.get(Constants.RESPONSE));
+        verify(redisDataService, times(1)).getMap(redisKey);
     }
 
     @Test
     void testExtendedProfile_cacheWriteFails() throws Exception {
         when(accessTokenValidator.fetchUserIdFromAccessToken(token)).thenReturn(userID);
-        when(cacheService.getCache(CACHE_KEY)).thenReturn(null);
         when(serverProperties.getContextType()).thenReturn(contextType);
-
         String contextJson = "[{\"a\":1}]";
         List<Map<String, Object>> records = List.of(Map.of(Constants.CONTEXT_DATA, contextJson));
         when(cassandraOperation.getRecordsByPropertiesByKey(any(), any(), any(), any(), any()))
                 .thenReturn(records);
-
         when(projectUtil.parseListOfMap(contextJson)).thenReturn(List.of(Map.of("a", 1)));
-
         ApiResponse response = profileService.getExtendedProfileSummary(userID, token);
-
         assertEquals(HttpStatus.OK, response.getResponseCode());
         assertNotNull(response.get(Constants.RESPONSE));
     }
@@ -410,7 +401,6 @@ class ProfileServiceImplTest {
     @Test
     void testExtendedProfile_emptyData() {
         when(accessTokenValidator.fetchUserIdFromAccessToken(token)).thenReturn(userID);
-        when(cacheService.getCache(CACHE_KEY)).thenReturn(null);
         when(serverProperties.getContextType()).thenReturn(contextType);
         when(cassandraOperation.getRecordsByPropertiesByKey(any(), any(), any(), any(), any()))
                 .thenReturn(Collections.emptyList());
@@ -424,24 +414,25 @@ class ProfileServiceImplTest {
     @Test
     void testExtendedProfile_cacheError_thenCassandraData() throws Exception {
         when(accessTokenValidator.fetchUserIdFromAccessToken(token)).thenReturn(userID);
-        when(cacheService.getCache(CACHE_KEY)).thenThrow(new RuntimeException("Simulated"));
-
+        String extendedProfileSummaryKey = "user:extendedProfileV2:all:" + userID;
+        when(redisDataService.getMap(extendedProfileSummaryKey)).thenThrow(new RuntimeException("Simulated"));
         when(serverProperties.getContextType()).thenReturn(contextType);
-
         String contextJson = "[{\"x\":\"1\"},{\"y\":\"2\"}]";
         List<Map<String, Object>> dbRecords = List.of(Map.of(Constants.CONTEXT_DATA, contextJson));
         when(cassandraOperation.getRecordsByPropertiesByKey(any(), any(), any(), any(), any()))
                 .thenReturn(dbRecords);
-
         List<Map<String, Object>> parsed = List.of(Map.of("x", "1"), Map.of("y", "2"));
         when(projectUtil.parseListOfMap(contextJson)).thenReturn(parsed);
-
-        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
-
         ApiResponse response = profileService.getExtendedProfileSummary(userID, token);
-
         assertEquals(HttpStatus.OK, response.getResponseCode());
-        assertNotNull(response.get(Constants.RESPONSE));
+        Map<String, Object> result = (Map<String, Object>) response.get(Constants.RESPONSE);
+        assertNotNull(result);
+        assertEquals(userID, result.get(Constants.USERID_KEY));
+        assertTrue(result.containsKey(contextType[0]));
+        Map<String, Object> ctx = (Map<String, Object>) result.get(contextType[0]);
+        assertEquals(2, ctx.get(Constants.COUNT));
+        List<?> dataList = (List<?>) ctx.get(Constants.DATA);
+        assertEquals(2, dataList.size());
     }
 
     @Test
@@ -455,49 +446,13 @@ class ProfileServiceImplTest {
     }
 
     @Test
-    void testCacheHit() throws Exception {
-        String cachedJson = "[{\"data\": \"test\"}]";
-        when(accessTokenValidator.fetchUserIdFromAccessToken(token)).thenReturn(userID);
-        when(cacheService.getCache(REDIS_KEY)).thenReturn(cachedJson);
-
-        List<Map<String, Object>> contextList = List.of(Map.of("data", "test"));
-        when(projectUtil.parseListOfMap(cachedJson)).thenReturn(contextList);
-
-        ApiResponse response = profileService.readFullExtendedProfile(userID, Arrays.toString(contextType), token);
-
-        assertEquals(HttpStatus.NO_CONTENT, response.getResponseCode());
-        assertEquals("No data found for user.", response.getParams().getErrMsg());
-    }
-
-    @Test
-    void testCacheMiss_thenFetchFromCassandra_success() throws Exception {
-        when(accessTokenValidator.fetchUserIdFromAccessToken(token)).thenReturn(userID);
-        when(cacheService.getCache(REDIS_KEY)).thenReturn(null);
-
-        String json = "[{\"data\": \"test\"}]";
-        Map<String, Object> cassandraRow = Map.of(Constants.CONTEXT_DATA, json);
-        when(cassandraOperation.getRecordsByPropertiesByKey(any(), any(), any(), any(), any()))
-                .thenReturn(List.of(cassandraRow));
-
-        List<Map<String, Object>> parsedList = List.of(Map.of("data", "test"));
-        when(projectUtil.parseListOfMap(json)).thenReturn(parsedList);
-        when(objectMapper.writeValueAsString(parsedList)).thenReturn(json);
-
-        ApiResponse response = profileService.readFullExtendedProfile(userID, Arrays.toString(contextType), token);
-
-        assertEquals(HttpStatus.OK, response.getResponseCode());
-        assertEquals(parsedList.size(), ((Map<?, ?>) response.getResult().get(Constants.RESPONSE)).get(Constants.COUNT));
-    }
-
-    @Test
     void testCacheMiss_thenFetchFromCassandra_emptyResult() {
         when(accessTokenValidator.fetchUserIdFromAccessToken(token)).thenReturn(userID);
-        when(cacheService.getCache(REDIS_KEY)).thenReturn(null);
+        when(redisDataService.getMapList(REDIS_KEY)).thenReturn(null);
         when(cassandraOperation.getRecordsByPropertiesByKey(any(), any(), any(), any(), any()))
                 .thenReturn(Collections.emptyList());
-
-        ApiResponse response = profileService.readFullExtendedProfile(userID, Arrays.toString(contextType), token);
-
+        String ctx = contextType[0];
+        ApiResponse response = profileService.readFullExtendedProfile(userID, ctx, token);
         assertEquals(HttpStatus.NO_CONTENT, response.getResponseCode());
         assertEquals(Constants.FAILED, response.getParams().getStatus());
     }
@@ -505,41 +460,35 @@ class ProfileServiceImplTest {
     @Test
     void testParseListOfMapException() throws Exception {
         when(accessTokenValidator.fetchUserIdFromAccessToken(token)).thenReturn(userID);
-        when(cacheService.getCache(REDIS_KEY)).thenReturn("[invalid_json]");
-        when(projectUtil.parseListOfMap("[invalid_json]")).thenThrow(new IOException("fail"));
-
-        // fallback to Cassandra
+        lenient().when(cacheService.getCache(REDIS_KEY)).thenReturn("[invalid_json]");
+        lenient().when(projectUtil.parseListOfMap("[invalid_json]")).thenThrow(new IOException("fail"));
         String json = "[{\"data\": \"test\"}]";
         Map<String, Object> cassandraRow = Map.of(Constants.CONTEXT_DATA, json);
-        when(cassandraOperation.getRecordsByPropertiesByKey(any(), any(), any(), any(), any()))
+        lenient().when(cassandraOperation.getRecordsByPropertiesByKey(any(), any(), any(), any(), any()))
                 .thenReturn(List.of(cassandraRow));
-        when(projectUtil.parseListOfMap(json)).thenReturn(List.of(Map.of("data", "test")));
-        when(objectMapper.writeValueAsString(any())).thenThrow(new RuntimeException("fail"));
-
+        lenient().when(projectUtil.parseListOfMap(json)).thenReturn(List.of(Map.of("data", "test")));
+        lenient().when(objectMapper.writeValueAsString(any())).thenThrow(new RuntimeException("fail"));
         ApiResponse response = profileService.readFullExtendedProfile(userID, Arrays.toString(contextType), token);
-
         assertEquals(HttpStatus.OK, response.getResponseCode());
     }
 
     @Test
-    void testLocationDetailsBranch() {
+    void testLocationDetailsBranch() throws Exception {
         String localContextType = Constants.LOCATION_DETAILS;
         String json = "[{\"location\": \"India\"}]";
-
+        List<Map<String, Object>> parsedList = List.of(Map.of("location", "India"));
         when(accessTokenValidator.fetchUserIdFromAccessToken(token)).thenReturn(userID);
-        when(cacheService.getCache(any())).thenReturn(null);
+        when(redisDataService.getMapList(any())).thenReturn(null);
         when(cassandraOperation.getRecordsByPropertiesByKey(any(), any(), any(), any(), any()))
                 .thenReturn(List.of(Map.of(Constants.CONTEXT_DATA, json)));
-        try {
-            lenient().when(projectUtil.parseListOfMap(json)).thenReturn(List.of(Map.of("location", "India")));
-            lenient().when(objectMapper.writeValueAsString(any())).thenReturn(json);
-        } catch (Exception e) {
-            fail("Should not throw exception");
-        }
-
+        when(projectUtil.parseListOfMap(json)).thenReturn(parsedList);
         ApiResponse response = profileService.readFullExtendedProfile(userID, localContextType, token);
         assertEquals(HttpStatus.OK, response.getResponseCode());
-        assertTrue(response.getResult().get(Constants.RESPONSE) instanceof Map);
+        assertInstanceOf(Map.class, response.getResult().get(Constants.RESPONSE));
+        Map<?, ?> responseMap = (Map<?, ?>) response.getResult().get(Constants.RESPONSE);
+        assertEquals("India", responseMap.get("location"));
+        verify(cassandraOperation, times(1)).getRecordsByPropertiesByKey(any(), any(), any(), any(), any());
+        verify(redisDataService, times(1)).getMapList(any());
     }
 
     @Test
@@ -1039,11 +988,12 @@ class ProfileServiceImplTest {
                 new ArrayList<>(List.of(new HashMap<>(Map.of("field", "value"))))
         );
         when(accessTokenValidator.fetchUserIdFromAccessToken(userToken)).thenReturn(userId);
-        doThrow(new RuntimeException("Cache error")).when(cacheService).putCache(anyString(), any());
+        when(redisDataService.getMap(anyString())).thenReturn(Collections.emptyMap());
+        doThrow(new RuntimeException("Cache error")).when(redisDataService).putMap(anyString(), any());
         ApiResponse response = profileService.getExtendedProfileSummary(userId, userToken);
         assertEquals(HttpStatus.OK, response.getResponseCode());
         assertNotNull(response.get(Constants.RESPONSE));
-        verify(cacheService).putCache(anyString(), any());
+        verify(redisDataService).putMap(anyString(), any());
     }
 
     @Test
@@ -1084,19 +1034,19 @@ class ProfileServiceImplTest {
     }
 
     @Test
-    void testReadFullExtendedProfile_NoContextData_ReturnsNoContent() throws Exception {
+    void testReadFullExtendedProfile_NoContextData_ReturnsNoContent() {
         String userId = "user-123";
         String userToken = "valid-token";
         String localContextType = "education";
-        String redisKey = "user:extendedProfile:" + localContextType + ":" + userId;
         when(accessTokenValidator.fetchUserIdFromAccessToken(userToken)).thenReturn(userId);
-        when(cacheService.getCache(redisKey)).thenReturn(null);
-        when(cassandraOperation.getRecordsByPropertiesByKey(anyString(), anyString(), anyMap(), any(), any()))
-                .thenReturn(null); // or Collections.emptyList()
-        lenient().when(projectUtil.parseListOfMap(anyString())).thenReturn(Collections.emptyList());
+        when(redisDataService.getMapList(anyString())).thenReturn(null);
+        when(cassandraOperation.getRecordsByPropertiesByKey(
+                anyString(), anyString(), anyMap(), any(), any())
+        ).thenReturn(null);
         ApiResponse response = profileService.readFullExtendedProfile(userId, localContextType, userToken);
         assertEquals(HttpStatus.NO_CONTENT, response.getResponseCode());
         assertEquals("No data found for user.", response.getParams().getErrMsg());
+        verify(redisDataService, never()).putMapList(anyString(), any());
     }
 
 

--- a/src/test/java/com/igot/cb/profile/ProfileServiceImplTest.java
+++ b/src/test/java/com/igot/cb/profile/ProfileServiceImplTest.java
@@ -504,13 +504,13 @@ class ProfileServiceImplTest {
         assertEquals("Invalid or missing access token", response.getParams().getErrMsg());
     }
 
-    // Use reflection to test private methods:
     @Test
     void testBuildCacheKey() throws Exception {
-        Method method = ProfileServiceImpl.class.getDeclaredMethod("buildCacheKey", String.class, String.class, String.class);
+        Method method = ProfileServiceImpl.class.getDeclaredMethod("buildCacheKey", String.class, String.class);
         method.setAccessible(true);
-        String key = (String) method.invoke(profileService, "user", "basicProfile", "u123");
-        assertEquals("user:basicProfile:u123", key);
+        String key = (String) method.invoke(profileService, "basicProfile", "u123");
+        String expected = String.join(":", Constants.USER_EXTENDED_PROFILE_V2_REDIS_KEY, "basicProfile", "u123");
+        assertEquals(expected, key);
     }
 
     @Test
@@ -1382,96 +1382,6 @@ class ProfileServiceImplTest {
         when(localCacheService.getCache("user:karmaPoints:" + userId)).thenThrow(new RuntimeException("Redis error"));
         int points = ReflectionTestUtils.invokeMethod(localService, "getUserKarmaPoints", userId);
         assertEquals(0, points);
-    }
-
-    @Test
-    void getSortingComparator_returnsServiceHistoryComparator_andSortsByStartDateDescending() {
-        ProfileServiceImpl localService = new ProfileServiceImpl();
-        Comparator<Map<String, Object>> comparator = ReflectionTestUtils.invokeMethod(localService, "getSortingComparator", Constants.SERVICE_HISTORY);
-        List<Map<String, Object>> data = new ArrayList<>();
-        data.add(Map.of(Constants.START_DATE, "2022-01-01T00:00:00Z"));
-        data.add(Map.of(Constants.START_DATE, "2023-01-01T00:00:00Z"));
-        data.sort(comparator.reversed());
-        assertEquals("2023-01-01T00:00:00Z", data.get(0).get(Constants.START_DATE));
-    }
-
-    @Test
-    void getSortingComparator_returnsEducationalQualificationsComparator_andSortsByStartYearDescending() {
-        ProfileServiceImpl localService = new ProfileServiceImpl();
-        Comparator<Map<String, Object>> comparator = ReflectionTestUtils.invokeMethod(localService, "getSortingComparator", Constants.EDUCATIONAL_QUALIFICATIONS);
-        List<Map<String, Object>> data = new ArrayList<>();
-        data.add(Map.of(Constants.START_YEAR, "2018"));
-        data.add(Map.of(Constants.START_YEAR, "2020"));
-        data.sort(comparator.reversed());
-        assertEquals("2020", data.get(0).get(Constants.START_YEAR));
-    }
-
-    @Test
-    void getSortingComparator_returnsAchievementsComparator_andSortsByIssuedDateDescending() {
-        ProfileServiceImpl localService = new ProfileServiceImpl();
-        Comparator<Map<String, Object>> comparator = ReflectionTestUtils.invokeMethod(localService, "getSortingComparator", Constants.ACHIVEMENTS);
-        List<Map<String, Object>> data = new ArrayList<>();
-        data.add(Map.of(Constants.ISSUED_DATE, "2021-05-01T00:00:00Z"));
-        data.add(Map.of(Constants.ISSUED_DATE, "2022-05-01T00:00:00Z"));
-        data.sort(comparator.reversed());
-        assertEquals("2022-05-01T00:00:00Z", data.get(0).get(Constants.ISSUED_DATE));
-    }
-
-    @Test
-    void getSortingComparator_returnsNullForUnknownContextType() {
-        ProfileServiceImpl localService = new ProfileServiceImpl();
-        Comparator<Map<String, Object>> comparator = ReflectionTestUtils.invokeMethod(localService, "getSortingComparator", "unknownType");
-        assertNull(comparator);
-    }
-
-    @Test
-    void getSortingComparator_handlesMissingFieldsGracefully() {
-        ProfileServiceImpl localService = new ProfileServiceImpl();
-        Comparator<Map<String, Object>> comparator = ReflectionTestUtils.invokeMethod(localService, "getSortingComparator", Constants.EDUCATIONAL_QUALIFICATIONS);
-        List<Map<String, Object>> data = new ArrayList<>();
-        data.add(new HashMap<>()); // missing START_YEAR
-        data.add(Map.of(Constants.START_YEAR, "2020"));
-        assertThrows(NumberFormatException.class, () -> data.sort(comparator));
-    }
-
-    @Test
-    void sortContextData_sortsListDescending_whenComparatorExists() {
-        ProfileServiceImpl localService = new ProfileServiceImpl();
-        List<Map<String, Object>> dataList = new ArrayList<>();
-        dataList.add(Map.of(Constants.START_DATE, "2022-01-01T00:00:00Z"));
-        dataList.add(Map.of(Constants.START_DATE, "2023-01-01T00:00:00Z"));
-        ReflectionTestUtils.invokeMethod(localService, "sortContextData", dataList, Constants.SERVICE_HISTORY);
-        assertEquals("2023-01-01T00:00:00Z", dataList.get(0).get(Constants.START_DATE));
-    }
-
-    @Test
-    void sortContextData_doesNotSort_whenComparatorIsNull() {
-        ProfileServiceImpl localService = new ProfileServiceImpl();
-        List<Map<String, Object>> dataList = new ArrayList<>();
-        dataList.add(Map.of("field", "A"));
-        dataList.add(Map.of("field", "B"));
-        List<Map<String, Object>> original = new ArrayList<>(dataList);
-        ReflectionTestUtils.invokeMethod(localService, "sortContextData", dataList, "unknownType");
-        assertEquals(original, dataList);
-    }
-
-    @Test
-    void sortContextData_handlesEmptyList() {
-        ProfileServiceImpl localService = new ProfileServiceImpl();
-        List<Map<String, Object>> dataList = new ArrayList<>();
-        ReflectionTestUtils.invokeMethod(localService, "sortContextData", dataList, Constants.SERVICE_HISTORY);
-        assertTrue(dataList.isEmpty());
-    }
-
-    @Test
-    void sortContextData_throwsException_whenFieldMissing() {
-        ProfileServiceImpl localService = new ProfileServiceImpl();
-        List<Map<String, Object>> dataList = new ArrayList<>();
-        dataList.add(new HashMap<>());
-        dataList.add(Map.of(Constants.START_YEAR, "2020"));
-        assertThrows(NumberFormatException.class, () ->
-                ReflectionTestUtils.invokeMethod(localService, "sortContextData", dataList, Constants.EDUCATIONAL_QUALIFICATIONS)
-        );
     }
 
     @Test

--- a/src/test/java/com/igot/cb/profile/ProfileServiceImplTest.java
+++ b/src/test/java/com/igot/cb/profile/ProfileServiceImplTest.java
@@ -11,6 +11,7 @@ import com.igot.cb.profile.service.ProfileServiceImpl;
 import com.igot.cb.transactional.cassandrautils.CassandraOperation;
 import com.igot.cb.transactional.elasticsearch.service.EsUtilServiceImpl;
 import com.igot.cb.transactional.redis.cache.CacheService;
+import com.igot.cb.transactional.redis.cache.RedissonRedisDataService;
 import com.igot.cb.transactional.service.RequestHandlerServiceImpl;
 import com.igot.cb.util.*;
 import org.junit.jupiter.api.BeforeEach;
@@ -1243,33 +1244,26 @@ class ProfileServiceImplTest {
     @Test
     void fetchFromDatabase_returnsRecordWithParsedProfileDetails_whenValidJson() throws Exception {
         ProfileServiceImpl locaService = new ProfileServiceImpl();
-
-        // Mock dependencies
         CassandraOperation localCassandraOperation = mock(CassandraOperation.class);
         CbServerProperties serverConfig = mock(CbServerProperties.class);
         ProjectUtil localProjectUtil = mock(ProjectUtil.class);
         CacheService localCacheService = mock(CacheService.class);
+        RedissonRedisDataService localRedisDataService = mock(RedissonRedisDataService.class);
         ObjectMapper mapper = new ObjectMapper();
-
         ReflectionTestUtils.setField(locaService, "cassandraOperation", localCassandraOperation);
         ReflectionTestUtils.setField(locaService, "serverConfig", serverConfig);
         ReflectionTestUtils.setField(locaService, "projectUtil", localProjectUtil);
         ReflectionTestUtils.setField(locaService, "cacheService", localCacheService);
-        ReflectionTestUtils.setField(locaService, "mapper", mapper);  // ✅ Fix for NPE
-
-        // DB record with JSON string
+        ReflectionTestUtils.setField(locaService, "redisDataService", localRedisDataService);
+        ReflectionTestUtils.setField(locaService, "mapper", mapper);
         Map<String, Object> localRecord = new HashMap<>();
         localRecord.put(Constants.PROFILE_DETAILS, "{\"email\":\"test@example.com\"}");
         List<Map<String, Object>> records = List.of(localRecord);
-
         when(localCassandraOperation.getRecordsByPropertiesByKey(anyString(), anyString(), anyMap(), any(), any()))
                 .thenReturn(records);
-
-        // Invoke the method with reflection
         Method method = ProfileServiceImpl.class.getDeclaredMethod("readUserDataFromDB", String.class, List.class);
         method.setAccessible(true);
         Map<String, Object> result = (Map<String, Object>) method.invoke(locaService, "user-2", null);
-
         assertNotNull(result);
         assertEquals("test@example.com", ((Map<?, ?>) result.get(Constants.PROFILE_DETAILS)).get("email"));
     }
@@ -1307,29 +1301,23 @@ class ProfileServiceImplTest {
     @Test
     void fetchFromDatabase_leavesProfileDetailsNull_whenProfileDetailsIsNull() {
         ProfileServiceImpl locaService = new ProfileServiceImpl();
-
-        // Mock dependencies
         CassandraOperation localCassandraOperation = mock(CassandraOperation.class);
         CbServerProperties serverConfig = mock(CbServerProperties.class);
         ProjectUtil localProjectUtil = mock(ProjectUtil.class);
         CacheService localCacheService = mock(CacheService.class);
-
-        // Set fields
+        RedissonRedisDataService localRedisDataService = mock(RedissonRedisDataService.class);
         ReflectionTestUtils.setField(locaService, "cassandraOperation", localCassandraOperation);
         ReflectionTestUtils.setField(locaService, "serverConfig", serverConfig);
         ReflectionTestUtils.setField(locaService, "projectUtil", localProjectUtil);
         ReflectionTestUtils.setField(locaService, "cacheService", localCacheService);
+        ReflectionTestUtils.setField(locaService, "redisDataService", localRedisDataService);
         ReflectionTestUtils.setField(locaService, "mapper", new ObjectMapper());
-
         Map<String, Object> localRecord = new HashMap<>();
         localRecord.put(Constants.PROFILE_DETAILS, null);
         List<Map<String, Object>> records = List.of(localRecord);
-
         when(localCassandraOperation.getRecordsByPropertiesByKey(anyString(), anyString(), anyMap(), any(), any()))
                 .thenReturn(records);
-
         Map<String, Object> result = ReflectionTestUtils.invokeMethod(locaService, "readUserDataFromDB", "user-4", null);
-
         assertNotNull(result);
         assertEquals(Map.of(), result.get(Constants.PROFILE_DETAILS));
     }
@@ -2777,94 +2765,105 @@ class ProfileServiceImplTest {
 
     @Test
     void getUserRoles_returnsRoles_whenScopesMatchRootOrgId() {
-        ProfileServiceImpl service = spy(new ProfileServiceImpl());
-        CassandraOperation cassandraOperation = mock(CassandraOperation.class);
-        ReflectionTestUtils.setField(service, "cassandraOperation", cassandraOperation);
+        ProfileServiceImpl testService = spy(new ProfileServiceImpl());
+        CassandraOperation cassandraMock = mock(CassandraOperation.class);
+        RedissonRedisDataService redisDataMock = mock(RedissonRedisDataService.class);
         ObjectMapper mapper = new ObjectMapper();
-        ReflectionTestUtils.setField(service, "mapper", mapper);
-
+        ReflectionTestUtils.setField(testService, "cassandraOperation", cassandraMock);
+        ReflectionTestUtils.setField(testService, "redisDataService", redisDataMock);
+        ReflectionTestUtils.setField(testService, "mapper", mapper);
         String userId = "user1";
         String rootOrgId = "org1";
+        when(redisDataMock.getStringList(anyString())).thenReturn(Collections.emptyList());
         Map<String, Object> userRoleObj = new HashMap<>();
         userRoleObj.put(Constants.ROLE, "admin");
         userRoleObj.put(Constants.SCOPE, List.of(Map.of(Constants.ORGANISATION_ID, rootOrgId)));
-        when(cassandraOperation.getRecordsByPropertiesByKey(anyString(), anyString(), anyMap(), anyList(), anyString()))
+        when(cassandraMock.getRecordsByPropertiesByKey(anyString(), anyString(), anyMap(), anyList(), anyString()))
                 .thenReturn(List.of(userRoleObj));
-
-        List<String> roles = service.getUserRoles(userId, rootOrgId);
+        List<String> roles = testService.getUserRoles(userId, rootOrgId);
         assertEquals(List.of("admin"), roles);
+        verify(redisDataMock).putStringList(anyString(), eq(List.of("admin")));
     }
 
     @Test
     void getUserRoles_returnsEmpty_whenScopesDoNotMatchRootOrgId() {
-        ProfileServiceImpl service = spy(new ProfileServiceImpl());
-        CassandraOperation cassandraOperation = mock(CassandraOperation.class);
-        ReflectionTestUtils.setField(service, "cassandraOperation", cassandraOperation);
+        ProfileServiceImpl testService = spy(new ProfileServiceImpl());
+        CassandraOperation cassandraMock = mock(CassandraOperation.class);
+        RedissonRedisDataService redisDataMock = mock(RedissonRedisDataService.class);
         ObjectMapper mapper = new ObjectMapper();
-        ReflectionTestUtils.setField(service, "mapper", mapper);
-
+        ReflectionTestUtils.setField(testService, "cassandraOperation", cassandraMock);
+        ReflectionTestUtils.setField(testService, "redisDataService", redisDataMock);
+        ReflectionTestUtils.setField(testService, "mapper", mapper);
         String userId = "user1";
         String rootOrgId = "org1";
+        when(redisDataMock.getStringList(anyString())).thenReturn(Collections.emptyList());
         Map<String, Object> userRoleObj = new HashMap<>();
         userRoleObj.put(Constants.ROLE, "admin");
         userRoleObj.put(Constants.SCOPE, List.of(Map.of(Constants.ORGANISATION_ID, "otherOrg")));
-        when(cassandraOperation.getRecordsByPropertiesByKey(anyString(), anyString(), anyMap(), anyList(), anyString()))
+        when(cassandraMock.getRecordsByPropertiesByKey(
+                anyString(), anyString(), anyMap(), anyList(), anyString()))
                 .thenReturn(List.of(userRoleObj));
-
-        List<String> roles = service.getUserRoles(userId, rootOrgId);
+        List<String> roles = testService.getUserRoles(userId, rootOrgId);
         assertTrue(roles.isEmpty());
+        verify(redisDataMock, never()).putStringList(anyString(), anyList());
     }
 
     @Test
-    void getUserRoles_parsesScopeString_whenScopeIsString() throws Exception {
-        ProfileServiceImpl service = spy(new ProfileServiceImpl());
-        CassandraOperation cassandraOperation = mock(CassandraOperation.class);
-        ReflectionTestUtils.setField(service, "cassandraOperation", cassandraOperation);
+    void getUserRoles_parsesScopeString_whenScopeIsString() {
+        ProfileServiceImpl testService = spy(new ProfileServiceImpl());
+        CassandraOperation cassandraMock = mock(CassandraOperation.class);
+        RedissonRedisDataService redisDataService = mock(RedissonRedisDataService.class);
         ObjectMapper mapper = new ObjectMapper();
-        ReflectionTestUtils.setField(service, "mapper", mapper);
-
+        ReflectionTestUtils.setField(testService, "cassandraOperation", cassandraMock);
+        ReflectionTestUtils.setField(testService, "redisDataService", redisDataService);
+        ReflectionTestUtils.setField(testService, "mapper", mapper);
         String userId = "user1";
         String rootOrgId = "org1";
+        when(redisDataService.getStringList(anyString())).thenReturn(Collections.emptyList());
         String scopeJson = "[{\"organisationId\":\"org1\"}]";
         Map<String, Object> userRoleObj = new HashMap<>();
         userRoleObj.put(Constants.ROLE, "admin");
         userRoleObj.put(Constants.SCOPE, scopeJson);
-        when(cassandraOperation.getRecordsByPropertiesByKey(anyString(), anyString(), anyMap(), anyList(), anyString()))
+        when(cassandraMock.getRecordsByPropertiesByKey(anyString(), anyString(), anyMap(), anyList(), anyString()))
                 .thenReturn(List.of(userRoleObj));
-
-        List<String> roles = service.getUserRoles(userId, rootOrgId);
+        List<String> roles = testService.getUserRoles(userId, rootOrgId);
         assertEquals(List.of("admin"), roles);
+        verify(redisDataService).putStringList(anyString(), eq(List.of("admin")));
     }
 
     @Test
     void getUserRoles_returnsEmpty_whenScopeStringIsInvalidJson() {
-        ProfileServiceImpl service = spy(new ProfileServiceImpl());
-        CassandraOperation cassandraOperation = mock(CassandraOperation.class);
-        ReflectionTestUtils.setField(service, "cassandraOperation", cassandraOperation);
+        ProfileServiceImpl testService = spy(new ProfileServiceImpl());
+        CassandraOperation cassandraOpMock = mock(CassandraOperation.class);
+        RedissonRedisDataService redisMock = mock(RedissonRedisDataService.class);
         ObjectMapper mapper = new ObjectMapper();
-        ReflectionTestUtils.setField(service, "mapper", mapper);
-
+        ReflectionTestUtils.setField(testService, "cassandraOperation", cassandraOpMock);
+        ReflectionTestUtils.setField(testService, "redisDataService", redisMock);
+        ReflectionTestUtils.setField(testService, "mapper", mapper);
         String userId = "user1";
         String rootOrgId = "org1";
         String invalidScopeJson = "not-a-json";
         Map<String, Object> userRoleObj = new HashMap<>();
         userRoleObj.put(Constants.ROLE, "admin");
         userRoleObj.put(Constants.SCOPE, invalidScopeJson);
-        when(cassandraOperation.getRecordsByPropertiesByKey(anyString(), anyString(), anyMap(), anyList(), anyString()))
+        when(redisMock.getStringList(anyString())).thenReturn(Collections.emptyList());
+        when(cassandraOpMock.getRecordsByPropertiesByKey(
+                anyString(), anyString(), anyMap(), anyList(), anyString()))
                 .thenReturn(List.of(userRoleObj));
-
-        List<String> roles = service.getUserRoles(userId, rootOrgId);
+        List<String> roles = testService.getUserRoles(userId, rootOrgId);
         assertTrue(roles.isEmpty());
+        verify(redisMock, never()).putStringList(anyString(), any());
     }
 
     @Test
     void getUserRoles_returnsDistinctRoles() {
-        ProfileServiceImpl service = spy(new ProfileServiceImpl());
-        CassandraOperation cassandraOperation = mock(CassandraOperation.class);
-        ReflectionTestUtils.setField(service, "cassandraOperation", cassandraOperation);
+        ProfileServiceImpl testService = spy(new ProfileServiceImpl());
+        CassandraOperation cassandraOpMock = mock(CassandraOperation.class);
+        RedissonRedisDataService redisDataServiceMock = mock(RedissonRedisDataService.class);
         ObjectMapper mapper = new ObjectMapper();
-        ReflectionTestUtils.setField(service, "mapper", mapper);
-
+        ReflectionTestUtils.setField(testService, "cassandraOperation", cassandraOpMock);
+        ReflectionTestUtils.setField(testService, "redisDataService", redisDataServiceMock);
+        ReflectionTestUtils.setField(testService, "mapper", mapper);
         String userId = "user1";
         String rootOrgId = "org1";
         Map<String, Object> userRoleObj1 = new HashMap<>();
@@ -2873,12 +2872,14 @@ class ProfileServiceImplTest {
         Map<String, Object> userRoleObj2 = new HashMap<>();
         userRoleObj2.put(Constants.ROLE, "admin");
         userRoleObj2.put(Constants.SCOPE, List.of(Map.of(Constants.ORGANISATION_ID, rootOrgId)));
-        when(cassandraOperation.getRecordsByPropertiesByKey(anyString(), anyString(), anyMap(), anyList(), anyString()))
+        when(redisDataServiceMock.getStringList(anyString())).thenReturn(Collections.emptyList());
+        when(cassandraOpMock.getRecordsByPropertiesByKey(anyString(), anyString(), anyMap(), anyList(), anyString()))
                 .thenReturn(List.of(userRoleObj1, userRoleObj2));
-
-        List<String> roles = service.getUserRoles(userId, rootOrgId);
+        List<String> roles = testService.getUserRoles(userId, rootOrgId);
         assertEquals(List.of("admin"), roles);
+        verify(redisDataServiceMock).putStringList(anyString(), eq(List.of("admin")));
     }
+
     @Test
     void updateAdditionalFields_returnsUnauthorized_whenAuthTokenBlank() {
         ApiResponse response = profileService.updateAdditionalFields(Map.of(), "");

--- a/src/test/java/com/igot/cb/transactional/redis/cache/RedissonRedisDataServiceTest.java
+++ b/src/test/java/com/igot/cb/transactional/redis/cache/RedissonRedisDataServiceTest.java
@@ -1,0 +1,144 @@
+package com.igot.cb.transactional.redis.cache;
+
+import com.igot.cb.util.CbServerProperties;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.redisson.api.*;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class RedissonRedisDataServiceTest {
+
+    @Mock
+    private RedissonClient redissonClient;
+
+    @Mock
+    private CbServerProperties cbServerProperties;
+
+    @Mock
+    private RKeys rKeys;
+
+    @Mock
+    private RMap<String, Object> rMap;
+
+    @Mock
+    private RList<String> rList;
+
+    @InjectMocks
+    private RedissonRedisDataService redisDataService;
+
+    private AutoCloseable closeable;
+
+    @BeforeEach
+    void setUp() {
+        closeable = MockitoAnnotations.openMocks(this);
+        when(redissonClient.getKeys()).thenReturn(rKeys);
+        when(cbServerProperties.getUserProfileKeysTtl()).thenReturn(5000);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        closeable.close();
+    }
+
+    @Test
+    void testPutMap_WithValidData_ShouldStoreInRedis() {
+        String redisKey = "user:map";
+        Map<String, Object> data = Map.of("key1", "value1");
+        when(rKeys.getType(redisKey)).thenReturn(RType.MAP);
+        when(redissonClient.<String, Object>getMap(redisKey)).thenReturn(rMap);
+        redisDataService.putMap(redisKey, data);
+        verify(rMap).putAll(data);
+        verify(rKeys).expire(redisKey, 5000L, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    void testPutMap_WithEmptyData_ShouldDoNothing() {
+        redisDataService.putMap("testKey", Collections.emptyMap());
+        verifyNoInteractions(rKeys, rMap);
+    }
+
+    @Test
+    void testPutMap_WithWrongType_ShouldDeleteAndRecreate() {
+        String redisKey = "user:map";
+        Map<String, Object> data = Map.of("a", "b");
+        when(rKeys.getType(redisKey)).thenReturn(RType.LIST);
+        when(redissonClient.<String, Object>getMap(redisKey)).thenReturn(rMap);
+        redisDataService.putMap(redisKey, data);
+        verify(rKeys).delete(redisKey);
+        verify(rMap).putAll(data);
+        verify(rKeys).expire(redisKey, 5000L, TimeUnit.MILLISECONDS);
+    }
+
+
+    @Test
+    void testGetMap_ShouldReturnMapFromRedis() {
+        String redisKey = "user:map";
+        Map<String, Object> mockMap = Map.of("k1", "v1");
+        when(redissonClient.<String, Object>getMap(redisKey)).thenReturn(rMap);
+        when(rMap.readAllMap()).thenReturn(mockMap);
+        Map<String, Object> result = redisDataService.getMap(redisKey);
+        assertEquals(mockMap, result);
+        verify(rMap).readAllMap();
+    }
+
+    @Test
+    void testPutStringList_WithValidList_ShouldStoreInRedis() {
+        String redisKey = "list:key";
+        List<String> list = List.of("a", "b");
+        when(rKeys.getType(redisKey)).thenReturn(RType.LIST);
+        when(redissonClient.<String>getList(redisKey)).thenReturn(rList);
+        redisDataService.putStringList(redisKey, list);
+        verify(rList).clear();
+        verify(rList).addAll(list);
+        verify(rKeys).expire(redisKey, 5000L, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    void testPutStringList_WithEmptyList_ShouldDoNothing() {
+        redisDataService.putStringList("list:key", Collections.emptyList());
+        verifyNoInteractions(rKeys, rList);
+    }
+
+    @Test
+    void testPutStringList_WithWrongType_ShouldDeleteAndRecreate() {
+        String redisKey = "list:key";
+        List<String> list = List.of("x", "y");
+        when(rKeys.getType(redisKey)).thenReturn(RType.MAP);
+        when(redissonClient.<String>getList(redisKey)).thenReturn(rList);
+        redisDataService.putStringList(redisKey, list);
+        verify(rKeys).delete(redisKey);
+        verify(rList).clear();
+        verify(rList).addAll(list);
+        verify(rKeys).expire(redisKey, 5000L, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    void testGetStringList_ShouldReturnListFromRedis() {
+        String redisKey = "list:key";
+        List<String> mockList = List.of("a", "b");
+        when(redissonClient.<String>getList(redisKey)).thenReturn(rList);
+        when(rList.isEmpty()).thenReturn(false);
+        when(rList.readAll()).thenReturn(mockList);
+        List<String> result = redisDataService.getStringList(redisKey);
+        assertEquals(mockList, result);
+    }
+
+    @Test
+    void testGetStringList_WhenEmpty_ShouldReturnEmptyList() {
+        when(redissonClient.<String>getList("list:key")).thenReturn(rList);
+        when(rList.isEmpty()).thenReturn(true);
+        List<String> result = redisDataService.getStringList("list:key");
+        assertTrue(result.isEmpty());
+    }
+}

--- a/src/test/java/com/igot/cb/transactional/redis/cache/RedissonRedisDataServiceTest.java
+++ b/src/test/java/com/igot/cb/transactional/redis/cache/RedissonRedisDataServiceTest.java
@@ -34,6 +34,9 @@ class RedissonRedisDataServiceTest {
     @Mock
     private RList<String> rList;
 
+    @Mock
+    private RList<Map<String, Object>> rMapList;
+
     @InjectMocks
     private RedissonRedisDataService redisDataService;
 
@@ -59,7 +62,7 @@ class RedissonRedisDataServiceTest {
         when(redissonClient.<String, Object>getMap(redisKey)).thenReturn(rMap);
         redisDataService.putMap(redisKey, data);
         verify(rMap).putAll(data);
-        verify(rKeys).expire(redisKey, 5000L, TimeUnit.MILLISECONDS);
+        verify(rKeys).expire(redisKey, 5000L, TimeUnit.SECONDS);
     }
 
     @Test
@@ -77,7 +80,7 @@ class RedissonRedisDataServiceTest {
         redisDataService.putMap(redisKey, data);
         verify(rKeys).delete(redisKey);
         verify(rMap).putAll(data);
-        verify(rKeys).expire(redisKey, 5000L, TimeUnit.MILLISECONDS);
+        verify(rKeys).expire(redisKey, 5000L, TimeUnit.SECONDS);
     }
 
 
@@ -101,7 +104,7 @@ class RedissonRedisDataServiceTest {
         redisDataService.putStringList(redisKey, list);
         verify(rList).clear();
         verify(rList).addAll(list);
-        verify(rKeys).expire(redisKey, 5000L, TimeUnit.MILLISECONDS);
+        verify(rKeys).expire(redisKey, 5000L, TimeUnit.SECONDS);
     }
 
     @Test
@@ -120,7 +123,7 @@ class RedissonRedisDataServiceTest {
         verify(rKeys).delete(redisKey);
         verify(rList).clear();
         verify(rList).addAll(list);
-        verify(rKeys).expire(redisKey, 5000L, TimeUnit.MILLISECONDS);
+        verify(rKeys).expire(redisKey, 5000L, TimeUnit.SECONDS);
     }
 
     @Test
@@ -139,6 +142,76 @@ class RedissonRedisDataServiceTest {
         when(redissonClient.<String>getList("list:key")).thenReturn(rList);
         when(rList.isEmpty()).thenReturn(true);
         List<String> result = redisDataService.getStringList("list:key");
+        assertTrue(result.isEmpty());
+    }
+
+
+    @Test
+    void testPutMapList_WithValidData_ShouldStoreInRedis() {
+        String redisKey = "maplist:key";
+        List<Map<String, Object>> list = List.of(Map.of("id", 1, "name", "John"));
+
+        when(rKeys.getType(redisKey)).thenReturn(RType.LIST);
+        when(redissonClient.<Map<String, Object>>getList(redisKey)).thenReturn(rMapList);
+
+        redisDataService.putMapList(redisKey, list);
+
+        verify(rMapList).clear();
+        verify(rMapList).addAll(list);
+        verify(rKeys).expire(redisKey, 5000L, TimeUnit.SECONDS);
+    }
+
+    @Test
+    void testPutMapList_WithEmptyList_ShouldDoNothing() {
+        redisDataService.putMapList("maplist:key", Collections.emptyList());
+        verifyNoInteractions(rKeys, rMapList);
+    }
+
+    @Test
+    void testPutMapList_WithWrongType_ShouldDeleteAndRecreate() {
+        String redisKey = "maplist:key";
+        List<Map<String, Object>> list = List.of(Map.of("foo", "bar"));
+
+        when(rKeys.getType(redisKey)).thenReturn(RType.MAP);
+        when(redissonClient.<Map<String, Object>>getList(redisKey)).thenReturn(rMapList);
+
+        redisDataService.putMapList(redisKey, list);
+
+        verify(rKeys).delete(redisKey);
+        verify(rMapList).clear();
+        verify(rMapList).addAll(list);
+        verify(rKeys).expire(redisKey, 5000L, TimeUnit.SECONDS);
+    }
+
+    @Test
+    void testGetMapList_ShouldReturnListFromRedis() {
+        String redisKey = "maplist:key";
+        List<Map<String, Object>> expected = List.of(Map.of("id", 1));
+
+        when(redissonClient.<Map<String, Object>>getList(redisKey)).thenReturn(rMapList);
+        when(rMapList.isEmpty()).thenReturn(false);
+        when(rMapList.readAll()).thenReturn(expected);
+
+        List<Map<String, Object>> result = redisDataService.getMapList(redisKey);
+
+        assertEquals(expected, result);
+        verify(rMapList).readAll();
+    }
+
+    @Test
+    void testGetMapList_WhenEmpty_ShouldReturnEmptyList() {
+        when(redissonClient.<Map<String, Object>>getList("maplist:key")).thenReturn(rMapList);
+        when(rMapList.isEmpty()).thenReturn(true);
+
+        List<Map<String, Object>> result = redisDataService.getMapList("maplist:key");
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testGetMapList_WhenNull_ShouldReturnEmptyList() {
+        when(redissonClient.<Map<String, Object>>getList("maplist:key")).thenReturn(null);
+        List<Map<String, Object>> result = redisDataService.getMapList("maplist:key");
         assertTrue(result.isEmpty());
     }
 }

--- a/src/test/java/com/igot/cb/transactional/redis/config/RedissonRedisConfigTest.java
+++ b/src/test/java/com/igot/cb/transactional/redis/config/RedissonRedisConfigTest.java
@@ -1,0 +1,64 @@
+package com.igot.cb.transactional.redis.config;
+
+import com.igot.cb.util.CbServerProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RedissonRedisConfigTest {
+
+    private CbServerProperties cbServerProperties;
+    private RedissonRedisConfig redissonRedisConfig;
+
+    @BeforeEach
+    void setUp() {
+        cbServerProperties = mock(CbServerProperties.class);
+        lenient().when(cbServerProperties.getRedisHostName()).thenReturn("localhost");
+        lenient().when(cbServerProperties.getRedisPort()).thenReturn("6379");
+        lenient().when(cbServerProperties.getRedisDataHostName()).thenReturn("localhost");
+        lenient().when(cbServerProperties.getRedisDataPort()).thenReturn("6380");
+        lenient().when(cbServerProperties.getRedisMaxTotal()).thenReturn(10);
+        lenient().when(cbServerProperties.getRedisMinIdle()).thenReturn(2);
+        redissonRedisConfig = new RedissonRedisConfig(cbServerProperties);
+    }
+
+
+    @Test
+    void testConstructor() {
+        RedissonRedisConfig config = new RedissonRedisConfig(cbServerProperties);
+        assertThat(config).isNotNull();
+    }
+
+    @Test
+    void testRedissonClient() {
+        RedissonClient mockClient = mock(RedissonClient.class);
+        try (MockedStatic<Redisson> redissonStatic = Mockito.mockStatic(Redisson.class)) {
+            redissonStatic.when(() -> Redisson.create(any(Config.class))).thenReturn(mockClient);
+            RedissonClient result = redissonRedisConfig.redissonClient();
+            assertThat(result).isEqualTo(mockClient);
+            redissonStatic.verify(() -> Redisson.create(any(Config.class)), times(1));
+        }
+    }
+
+    @Test
+    void testRedissonDataPopulationClient() {
+        RedissonClient mockClient = mock(RedissonClient.class);
+        try (MockedStatic<Redisson> redissonStatic = Mockito.mockStatic(Redisson.class)) {
+            redissonStatic.when(() -> Redisson.create(any(Config.class))).thenReturn(mockClient);
+            RedissonClient result = redissonRedisConfig.redissonDataPopulationClient();
+            assertThat(result).isEqualTo(mockClient);
+            redissonStatic.verify(() -> Redisson.create(any(Config.class)), times(1));
+        }
+    }
+}


### PR DESCRIPTION
1. Added new open source redis package - redisson-redis . This package allows us to save the List, Map as is as and retrieve the details. Json to String and viceversa conversion would be altered.
2. Updated the userprofile key to v2 .
3. Reduced the cognitive complexity of calculateProfileCompletionPercentage and implemented caching.
4. Implemented caching for getUserRoles .
5. Reduced the cognitive complexity of the sanitizeProfile. 6.Implemented the Junit test cases.