### PR TITLE
redis-password-support

### DIFF
--- a/src/main/java/com/igot/cb/transactional/redis/config/RedisConfig.java
+++ b/src/main/java/com/igot/cb/transactional/redis/config/RedisConfig.java
@@ -10,8 +10,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.util.StringUtils;
-import redis.clients.jedis.JedisPool;
-import redis.clients.jedis.JedisPoolConfig;
+import redis.clients.jedis.*;
 
 @Configuration
 @EnableCaching
@@ -39,7 +38,7 @@ public class RedisConfig {
         int redisPort = Integer.parseInt(port);
         if (StringUtils.hasText(password)) {
             log.info("Redis server {}:{} is configured with password authentication", host, redisPort);
-            return new JedisPool(poolConfig, host, redisPort, null, password);
+            return new JedisPool(poolConfig, host, redisPort, Protocol.DEFAULT_TIMEOUT, password);
         }
         log.warn("Redis server {}:{} is configured without password authentication", host, redisPort);
         return new JedisPool(poolConfig, host, redisPort);

--- a/src/main/java/com/igot/cb/transactional/redis/config/RedisConfig.java
+++ b/src/main/java/com/igot/cb/transactional/redis/config/RedisConfig.java
@@ -65,6 +65,9 @@ public class RedisConfig {
         org.springframework.data.redis.connection.jedis.JedisConnectionFactory jedisConnectionFactory = new org.springframework.data.redis.connection.jedis.JedisConnectionFactory();
         jedisConnectionFactory.setHostName(cbProperties.getRedisHostName());
         jedisConnectionFactory.setPort(Integer.parseInt(cbProperties.getRedisPort()));
+        if (StringUtils.hasText(cbProperties.getRedisPassword())) {
+            jedisConnectionFactory.setPassword(cbProperties.getRedisPassword());
+        }
         jedisConnectionFactory.afterPropertiesSet();
         RedisTemplate<String, SearchResult> template = new RedisTemplate<>();
         template.setConnectionFactory(jedisConnectionFactory);

--- a/src/main/java/com/igot/cb/transactional/redis/config/RedisConfig.java
+++ b/src/main/java/com/igot/cb/transactional/redis/config/RedisConfig.java
@@ -3,6 +3,7 @@ package com.igot.cb.transactional.redis.config;
 import com.igot.cb.transactional.elasticsearch.dto.SearchResult;
 import com.igot.cb.util.CbServerProperties;
 import com.igot.cb.util.Constants;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
@@ -14,6 +15,7 @@ import redis.clients.jedis.JedisPoolConfig;
 
 @Configuration
 @EnableCaching
+@Slf4j
 public class RedisConfig {
 
     @Autowired
@@ -36,8 +38,10 @@ public class RedisConfig {
     private JedisPool createJedisPool(JedisPoolConfig poolConfig, String host, String port, String password) {
         int redisPort = Integer.parseInt(port);
         if (StringUtils.hasText(password)) {
+            log.info("Redis server {}:{} is configured with password authentication", host, redisPort);
             return new JedisPool(poolConfig, host, redisPort, null, password);
         }
+        log.warn("Redis server {}:{} is configured without password authentication", host, redisPort);
         return new JedisPool(poolConfig, host, redisPort);
     }
 

--- a/src/main/java/com/igot/cb/transactional/redis/config/RedisConfig.java
+++ b/src/main/java/com/igot/cb/transactional/redis/config/RedisConfig.java
@@ -8,6 +8,7 @@ import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.util.StringUtils;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisPoolConfig;
 
@@ -21,16 +22,23 @@ public class RedisConfig {
     @Bean
     public JedisPool jedisPool() {
         final JedisPoolConfig poolConfig = buildPoolConfig();
-        JedisPool jedisPool = new JedisPool(poolConfig, cbProperties.getRedisHostName(),
-                Integer.parseInt(cbProperties.getRedisPort()));
-        return jedisPool;
+        return createJedisPool(poolConfig, cbProperties.getRedisHostName(), cbProperties.getRedisPort(),
+                cbProperties.getRedisPassword());
     }
 
     @Bean
     public JedisPool jedisDataPopulationPool() {
         final JedisPoolConfig poolConfig = buildPoolConfig();
-        return new JedisPool(poolConfig, cbProperties.getRedisDataHostName(),
-                Integer.parseInt(cbProperties.getRedisDataPort()));
+        return createJedisPool(poolConfig, cbProperties.getRedisDataHostName(), cbProperties.getRedisDataPort(),
+                cbProperties.getRedisDataPassword());
+    }
+
+    private JedisPool createJedisPool(JedisPoolConfig poolConfig, String host, String port, String password) {
+        int redisPort = Integer.parseInt(port);
+        if (StringUtils.hasText(password)) {
+            return new JedisPool(poolConfig, host, redisPort, null, password);
+        }
+        return new JedisPool(poolConfig, host, redisPort);
     }
 
     private JedisPoolConfig buildPoolConfig() {

--- a/src/main/java/com/igot/cb/util/CbServerProperties.java
+++ b/src/main/java/com/igot/cb/util/CbServerProperties.java
@@ -85,11 +85,25 @@ public class CbServerProperties {
     @Value("${redis.port}")
     private String redisPort;
 
+    /**
+     * Optional password for the primary Redis server. An empty value keeps
+     * compatibility with Redis servers that do not require authentication.
+     */
+    @Value("${redis.password:}")
+    private String redisPassword;
+
     @Value("${redis.data.host.name}")
     private String redisDataHostName;
 
     @Value("${redis.data.port}")
     private String redisDataPort;
+
+    /**
+     * Optional password for the Redis data-population server. An empty value
+     * keeps compatibility with Redis servers that do not require authentication.
+     */
+    @Value("${redis.data.password:}")
+    private String redisDataPassword;
 
     @Value("${cb.redis.maxIdle}")
     private Integer redisMaxIdle;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -96,8 +96,13 @@ community.base.url=http://discussion-metaupdate-service:7002
 community.post.count.api.url=/v1/postcount/
 redis.host.name=localhost
 redis.port=6379
+# Leave blank for Redis servers without authentication. Supply through deployment
+# configuration or a secret; do not commit a real password to this file.
+redis.password=
 redis.data.host.name=localhost
 redis.data.port=6379
+# May differ from redis.password when the data-population server is separate.
+redis.data.password=
 cb.redis.maxIdle=128
 cb.redis.maxTotal=3000
 cb.redis.minIdle=100

--- a/src/test/java/com/igot/cb/transactional/redis/config/RedisConfigTest.java
+++ b/src/test/java/com/igot/cb/transactional/redis/config/RedisConfigTest.java
@@ -1,14 +1,20 @@
 package com.igot.cb.transactional.redis.config;
 
+import com.igot.cb.transactional.elasticsearch.dto.SearchResult;
 import com.igot.cb.util.CbServerProperties;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.util.ReflectionTestUtils;
+import redis.clients.jedis.JedisClientConfig;
 import redis.clients.jedis.JedisPool;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -18,9 +24,85 @@ class RedisConfigTest {
     private CbServerProperties cbProperties;
 
     @Test
-    void jedisPool_ReturnsConfiguredJedisPool() {
-        when(cbProperties.getRedisHostName()).thenReturn("localhost");
-        when(cbProperties.getRedisPort()).thenReturn("6379");
+    void jedisPool_ConfiguresPasswordWhenProvided() {
+        configurePrimaryRedis();
+        when(cbProperties.getRedisPassword()).thenReturn("primary-secret");
+
+        JedisPool pool = redisConfig().jedisPool();
+        try {
+            assertNotNull(pool);
+            assertEquals("primary-secret", getPassword(pool));
+        } finally {
+            pool.close();
+        }
+    }
+
+    @Test
+    void jedisPool_DoesNotConfigurePasswordWhenBlank() {
+        configurePrimaryRedis();
+        when(cbProperties.getRedisPassword()).thenReturn("   ");
+
+        JedisPool pool = redisConfig().jedisPool();
+        try {
+            assertNull(getPassword(pool));
+        } finally {
+            pool.close();
+        }
+    }
+
+    @Test
+    void jedisDataPopulationPool_ConfiguresItsOwnPasswordWhenProvided() {
+        configureDataRedis();
+        when(cbProperties.getRedisDataPassword()).thenReturn("data-secret");
+
+        JedisPool pool = redisConfig().jedisDataPopulationPool();
+        try {
+            assertNotNull(pool);
+            assertEquals("data-secret", getPassword(pool));
+        } finally {
+            pool.close();
+        }
+    }
+
+    @Test
+    void jedisDataPopulationPool_DoesNotConfigurePasswordWhenMissing() {
+        configureDataRedis();
+
+        JedisPool pool = redisConfig().jedisDataPopulationPool();
+        try {
+            assertNull(getPassword(pool));
+        } finally {
+            pool.close();
+        }
+    }
+
+    @Test
+    void searchResultRedisTemplate_ConfiguresPrimaryPasswordWhenProvided() {
+        configurePrimaryRedisEndpoint();
+        when(cbProperties.getRedisPassword()).thenReturn("primary-secret");
+
+        RedisTemplate<String, SearchResult> template = redisConfig().searchResultRedisTemplate();
+        JedisConnectionFactory connectionFactory = (JedisConnectionFactory) template.getConnectionFactory();
+
+        assertNotNull(connectionFactory);
+        assertEquals("primary-secret", connectionFactory.getPassword());
+        connectionFactory.destroy();
+    }
+
+    @Test
+    void searchResultRedisTemplate_DoesNotConfigurePasswordWhenMissing() {
+        configurePrimaryRedisEndpoint();
+
+        RedisTemplate<String, SearchResult> template = redisConfig().searchResultRedisTemplate();
+        JedisConnectionFactory connectionFactory = (JedisConnectionFactory) template.getConnectionFactory();
+
+        assertNotNull(connectionFactory);
+        assertNull(connectionFactory.getPassword());
+        connectionFactory.destroy();
+    }
+
+    private void configurePrimaryRedis() {
+        configurePrimaryRedisEndpoint();
         when(cbProperties.getRedisMaxIdle()).thenReturn(5);
         when(cbProperties.getRedisMaxTotal()).thenReturn(10);
         when(cbProperties.getRedisMinIdle()).thenReturn(1);
@@ -30,16 +112,14 @@ class RedisConfigTest {
         when(cbProperties.getRedisMinEvictableIdleTimeMillis()).thenReturn(60000L);
         when(cbProperties.getRedisNumTestsPerEvictionRun()).thenReturn(3);
         when(cbProperties.getRedisBlockWhenExhausted()).thenReturn(true);
-
-        RedisConfig redisConfig = new RedisConfig();
-        ReflectionTestUtils.setField(redisConfig, "cbProperties", cbProperties);
-
-        JedisPool pool = redisConfig.jedisPool();
-        assertNotNull(pool);
     }
 
-    @Test
-    void jedisDataPopulationPool_ReturnsConfiguredJedisPool() {
+    private void configurePrimaryRedisEndpoint() {
+        when(cbProperties.getRedisHostName()).thenReturn("localhost");
+        when(cbProperties.getRedisPort()).thenReturn("6379");
+    }
+
+    private void configureDataRedis() {
         when(cbProperties.getRedisDataHostName()).thenReturn("localhost");
         when(cbProperties.getRedisDataPort()).thenReturn("6380");
         when(cbProperties.getRedisMaxIdle()).thenReturn(2);
@@ -51,11 +131,16 @@ class RedisConfigTest {
         when(cbProperties.getRedisMinEvictableIdleTimeMillis()).thenReturn(120000L);
         when(cbProperties.getRedisNumTestsPerEvictionRun()).thenReturn(2);
         when(cbProperties.getRedisBlockWhenExhausted()).thenReturn(false);
+    }
 
+    private RedisConfig redisConfig() {
         RedisConfig redisConfig = new RedisConfig();
         ReflectionTestUtils.setField(redisConfig, "cbProperties", cbProperties);
+        return redisConfig;
+    }
 
-        JedisPool pool = redisConfig.jedisDataPopulationPool();
-        assertNotNull(pool);
+    private String getPassword(JedisPool pool) {
+        Object clientConfig = ReflectionTestUtils.getField(pool.getFactory(), "clientConfig");
+        return ((JedisClientConfig) clientConfig).getPassword();
     }
 }


### PR DESCRIPTION
Redis configuration now supports both authenticated and unauthenticated Redis servers through deployment properties.
• Added optional redis.password for the primary Redis server.
• Added optional redis.data.password for the data-population Redis server.
• When a password is configured, Redis connections authenticate using it.
• When the password is blank or not provided, connections are created without authentication—maintaining compatibility with existing non-password Redis servers.
• The two Redis servers can be configured independently: one can require a password while the other remains unauthenticated.
• The primary Redis password is applied to both the main Jedis pool and the search-result Redis template.
• Passwords should be supplied through environment-specific configuration or secrets, not committed in source code.