### PR TITLE
Redis password authentication 4.8.40.1

### DIFF
--- a/src/main/java/com/igot/cb/transactional/redis/config/RedisConfig.java
+++ b/src/main/java/com/igot/cb/transactional/redis/config/RedisConfig.java
@@ -3,6 +3,8 @@ package com.igot.cb.transactional.redis.config;
 import com.igot.cb.transactional.elasticsearch.dto.SearchResult;
 import com.igot.cb.util.CbServerProperties;
 import com.igot.cb.util.Constants;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
@@ -13,6 +15,7 @@ import redis.clients.jedis.JedisPoolConfig;
 
 @Configuration
 @EnableCaching
+@Slf4j
 public class RedisConfig {
 
     @Autowired
@@ -20,17 +23,56 @@ public class RedisConfig {
 
     @Bean
     public JedisPool jedisPool() {
-        final JedisPoolConfig poolConfig = buildPoolConfig();
-        JedisPool jedisPool = new JedisPool(poolConfig, cbProperties.getRedisHostName(),
-                Integer.parseInt(cbProperties.getRedisPort()));
-        return jedisPool;
+        return buildPool(cbProperties.getRedisHostName(),
+                Integer.parseInt(cbProperties.getRedisPort()),
+                cbProperties.isRedisPasswordRequired(),
+                cbProperties.getRedisUsername(),
+                cbProperties.getRedisPassword());
     }
 
     @Bean
     public JedisPool jedisDataPopulationPool() {
+        return buildPool(cbProperties.getRedisDataHostName(),
+                Integer.parseInt(cbProperties.getRedisDataPort()),
+                cbProperties.isRedisDataPasswordRequired(),
+                cbProperties.getRedisDataUsername(),
+                cbProperties.getRedisDataPassword());
+    }
+
+    /**
+     * Builds one pool, authenticated or not, for whichever of the two Redis servers the arguments
+     * describe. The two servers are configured independently, so one may require credentials while
+     * the other does not.
+     */
+    private JedisPool buildPool(String host, int port, boolean passwordRequired, String username, String password) {
         final JedisPoolConfig poolConfig = buildPoolConfig();
-        return new JedisPool(poolConfig, cbProperties.getRedisDataHostName(),
-                Integer.parseInt(cbProperties.getRedisDataPort()));
+
+        if (!passwordRequired) {
+            log.warn("Redis pool for {}:{} created WITHOUT authentication - if that server has requirepass set, every operation will fail with NOAUTH and be swallowed as a cache miss", host, port);
+            return new JedisPool(poolConfig, host, port);
+        }
+        requireCredentials(host, port, username, password);
+        // The username is safe to log and is what makes an ACL misconfiguration diagnosable from the
+        // startup line alone; the password must never appear here.
+        log.info("Redis pool for {}:{} created with authentication enabled for user '{}'", host, port, username);
+        return new JedisPool(poolConfig, host, port, username, password);
+    }
+
+    /**
+     * Fails at bean creation rather than on the first Redis call. An unset property reads as "" rather
+     * than null, and Jedis sends the two-argument AUTH whenever the username is non-null - so without
+     * this guard the server answers WRONGPASS on every command and CacheService swallows it as a miss.
+     *
+     * <p>Shared by {@link #buildPool} and {@link #searchResultRedisTemplate()}, which reach the same
+     * cache instance by two different routes.
+     */
+    private void requireCredentials(String host, int port, String username, String password) {
+        if (StringUtils.isBlank(username)) {
+            throw new IllegalStateException("A username is required for the Redis instance at " + host + ":" + port + " but not configured");
+        }
+        if (StringUtils.isBlank(password)) {
+            throw new IllegalStateException("A password is required for the Redis instance at " + host + ":" + port + " but not configured");
+        }
     }
 
     private JedisPoolConfig buildPoolConfig() {
@@ -53,6 +95,18 @@ public class RedisConfig {
         org.springframework.data.redis.connection.jedis.JedisConnectionFactory jedisConnectionFactory = new org.springframework.data.redis.connection.jedis.JedisConnectionFactory();
         jedisConnectionFactory.setHostName(cbProperties.getRedisHostName());
         jedisConnectionFactory.setPort(Integer.parseInt(cbProperties.getRedisPort()));
+        // This template builds its own connection factory and so does NOT inherit the credentials
+        // applied to jedisPool, even though it points at the same cache instance. Without this the
+        // pools would authenticate and this bean alone would fail with NOAUTH. It reaches the cache
+        // server, so it takes the redis.* credentials, never redis.data.*.
+        if (cbProperties.isRedisPasswordRequired()) {
+            requireCredentials(cbProperties.getRedisHostName(), Integer.parseInt(cbProperties.getRedisPort()),
+                    cbProperties.getRedisUsername(), cbProperties.getRedisPassword());
+            // JedisConnectionFactory exposes setPassword but has no setUsername, so the username has
+            // to go through the standalone configuration. Both must be set before afterPropertiesSet.
+            jedisConnectionFactory.getStandaloneConfiguration().setUsername(cbProperties.getRedisUsername());
+            jedisConnectionFactory.setPassword(cbProperties.getRedisPassword());
+        }
         jedisConnectionFactory.afterPropertiesSet();
         RedisTemplate<String, SearchResult> template = new RedisTemplate<>();
         template.setConnectionFactory(jedisConnectionFactory);

--- a/src/main/java/com/igot/cb/util/CbServerProperties.java
+++ b/src/main/java/com/igot/cb/util/CbServerProperties.java
@@ -85,11 +85,29 @@ public class CbServerProperties {
     @Value("${redis.port}")
     private String redisPort;
 
+    @Value("${redis.password.required:false}")
+    private boolean redisPasswordRequired;
+
+    @Value("${redis.username:}")
+    private String redisUsername;
+
+    @Value("${redis.password:}")
+    private String redisPassword;
+
     @Value("${redis.data.host.name}")
     private String redisDataHostName;
 
     @Value("${redis.data.port}")
     private String redisDataPort;
+
+    @Value("${redis.data.password.required:false}")
+    private boolean redisDataPasswordRequired;
+
+    @Value("${redis.data.username:}")
+    private String redisDataUsername;
+
+    @Value("${redis.data.password:}")
+    private String redisDataPassword;
 
     @Value("${cb.redis.maxIdle}")
     private Integer redisMaxIdle;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -96,8 +96,20 @@ community.base.url=http://discussion-metaupdate-service:7002
 community.post.count.api.url=/v1/postcount/
 redis.host.name=localhost
 redis.port=6379
+redis.password.required=false
+# When redis.password.required=true BOTH of these are mandatory and the application refuses to
+# start without them. Supply the real values as environment variables in deployed environments,
+# never in this file. Use `default` as the username for a server running plain requirepass.
+# These also cover the searchResultRedisTemplate, which reaches the same cache instance.
+redis.username=
+redis.password=
 redis.data.host.name=localhost
 redis.data.port=6379
+redis.data.password.required=false
+# Same contract as redis.* above: with the flag on, both of these are mandatory.
+# Supply the real values as environment variables in deployed environments, never in this file.
+redis.data.username=
+redis.data.password=
 cb.redis.maxIdle=128
 cb.redis.maxTotal=3000
 cb.redis.minIdle=100

--- a/src/test/java/com/igot/cb/transactional/redis/config/RedisConfigTest.java
+++ b/src/test/java/com/igot/cb/transactional/redis/config/RedisConfigTest.java
@@ -9,6 +9,8 @@ import org.springframework.test.util.ReflectionTestUtils;
 import redis.clients.jedis.JedisPool;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -57,5 +59,117 @@ class RedisConfigTest {
 
         JedisPool pool = redisConfig.jedisDataPopulationPool();
         assertNotNull(pool);
+    }
+
+    /**
+     * With the flag on, a missing username must fail at bean creation rather than on the first Redis
+     * call. An unset property reads as "" rather than null, and Jedis sends the two-argument AUTH
+     * whenever the username is non-null - so without this guard the server answers WRONGPASS on every
+     * command and CacheService swallows it as a miss.
+     */
+    @Test
+    void jedisPool_FailsWhenUsernameRequiredButMissing() {
+        when(cbProperties.getRedisHostName()).thenReturn("localhost");
+        when(cbProperties.getRedisPort()).thenReturn("6379");
+        when(cbProperties.isRedisPasswordRequired()).thenReturn(true);
+        when(cbProperties.getRedisUsername()).thenReturn("");
+        when(cbProperties.getRedisPassword()).thenReturn("cache-secret");
+
+        RedisConfig redisConfig = new RedisConfig();
+        ReflectionTestUtils.setField(redisConfig, "cbProperties", cbProperties);
+
+        IllegalStateException ex = assertThrows(IllegalStateException.class, redisConfig::jedisPool);
+        assertTrue(ex.getMessage().contains("username"), ex.getMessage());
+        // the message must point at the cache instance, not the data one
+        assertTrue(ex.getMessage().contains("localhost:6379"), ex.getMessage());
+    }
+
+    @Test
+    void jedisPool_FailsWhenPasswordRequiredButMissing() {
+        when(cbProperties.getRedisHostName()).thenReturn("localhost");
+        when(cbProperties.getRedisPort()).thenReturn("6379");
+        when(cbProperties.isRedisPasswordRequired()).thenReturn(true);
+        when(cbProperties.getRedisUsername()).thenReturn("cache-user");
+        when(cbProperties.getRedisPassword()).thenReturn("  ");
+
+        RedisConfig redisConfig = new RedisConfig();
+        ReflectionTestUtils.setField(redisConfig, "cbProperties", cbProperties);
+
+        IllegalStateException ex = assertThrows(IllegalStateException.class, redisConfig::jedisPool);
+        assertTrue(ex.getMessage().contains("password"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("localhost:6379"), ex.getMessage());
+    }
+
+    /**
+     * An absent key reads as null rather than "". Both spellings of "not configured" are rejected.
+     */
+    @Test
+    void jedisPool_FailsWhenUsernameIsNull() {
+        when(cbProperties.getRedisHostName()).thenReturn("localhost");
+        when(cbProperties.getRedisPort()).thenReturn("6379");
+        when(cbProperties.isRedisPasswordRequired()).thenReturn(true);
+        when(cbProperties.getRedisUsername()).thenReturn(null);
+        when(cbProperties.getRedisPassword()).thenReturn("cache-secret");
+
+        RedisConfig redisConfig = new RedisConfig();
+        ReflectionTestUtils.setField(redisConfig, "cbProperties", cbProperties);
+
+        IllegalStateException ex = assertThrows(IllegalStateException.class, redisConfig::jedisPool);
+        assertTrue(ex.getMessage().contains("username"), ex.getMessage());
+    }
+
+    /** The same two guards on the data pool, which is configured independently. */
+    @Test
+    void jedisDataPopulationPool_FailsWhenUsernameRequiredButMissing() {
+        when(cbProperties.getRedisDataHostName()).thenReturn("localhost");
+        when(cbProperties.getRedisDataPort()).thenReturn("6380");
+        when(cbProperties.isRedisDataPasswordRequired()).thenReturn(true);
+        when(cbProperties.getRedisDataUsername()).thenReturn("");
+        when(cbProperties.getRedisDataPassword()).thenReturn("data-secret");
+
+        RedisConfig redisConfig = new RedisConfig();
+        ReflectionTestUtils.setField(redisConfig, "cbProperties", cbProperties);
+
+        IllegalStateException ex = assertThrows(IllegalStateException.class, redisConfig::jedisDataPopulationPool);
+        assertTrue(ex.getMessage().contains("username"), ex.getMessage());
+        // and at the data instance - the port is what tells the two apart
+        assertTrue(ex.getMessage().contains("localhost:6380"), ex.getMessage());
+    }
+
+    @Test
+    void jedisDataPopulationPool_FailsWhenPasswordRequiredButMissing() {
+        when(cbProperties.getRedisDataHostName()).thenReturn("localhost");
+        when(cbProperties.getRedisDataPort()).thenReturn("6380");
+        when(cbProperties.isRedisDataPasswordRequired()).thenReturn(true);
+        when(cbProperties.getRedisDataUsername()).thenReturn("data-user");
+        when(cbProperties.getRedisDataPassword()).thenReturn("  ");
+
+        RedisConfig redisConfig = new RedisConfig();
+        ReflectionTestUtils.setField(redisConfig, "cbProperties", cbProperties);
+
+        IllegalStateException ex = assertThrows(IllegalStateException.class, redisConfig::jedisDataPopulationPool);
+        assertTrue(ex.getMessage().contains("password"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("localhost:6380"), ex.getMessage());
+    }
+
+    /**
+     * searchResultRedisTemplate builds its own connection factory and so does not inherit the pool's
+     * credentials. It must trip the same guard, or flipping the flag on yields a service where the
+     * pools authenticate and this one bean fails with NOAUTH.
+     */
+    @Test
+    void searchResultRedisTemplate_FailsWhenCredentialsRequiredButMissing() {
+        when(cbProperties.getRedisHostName()).thenReturn("localhost");
+        when(cbProperties.getRedisPort()).thenReturn("6379");
+        when(cbProperties.isRedisPasswordRequired()).thenReturn(true);
+        when(cbProperties.getRedisUsername()).thenReturn("");
+        when(cbProperties.getRedisPassword()).thenReturn("cache-secret");
+
+        RedisConfig redisConfig = new RedisConfig();
+        ReflectionTestUtils.setField(redisConfig, "cbProperties", cbProperties);
+
+        IllegalStateException ex = assertThrows(IllegalStateException.class, redisConfig::searchResultRedisTemplate);
+        assertTrue(ex.getMessage().contains("username"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("localhost:6379"), ex.getMessage());
     }
 }


### PR DESCRIPTION
Ports the opt-in Redis authentication from KB-iGOT/cb-ext-course-service#345 to this service, adapted to its existing structure rather than copied.

### Why

Both `JedisPool`s are built with no credentials. If the Redis server is given a `requirepass` or an ACL user, every command comes back `NOAUTH` — and because `CacheService` wraps its calls in `try/catch` that log and return null, that failure is indistinguishable from a cache miss. The service keeps serving with a permanently cold cache and nothing surfaces.

### What changed

- `CbServerProperties` — six new `@Value` fields: `redis.password.required` / `redis.username` / `redis.password`, and the `redis.data.*` equivalents.
- `RedisConfig` — a private `buildPool(...)` that both pools route through, a shared `requireCredentials(...)`, plus `@Slf4j`.
- **`searchResultRedisTemplate` now authenticates too** — see below.
- `application.properties` — the six keys, defaulting to the current unauthenticated behaviour.

### Behaviour

| Flag | Result |
|---|---|
| `false` (default) | pool built unauthenticated, exactly as today, with a warning explaining the NOAUTH-as-cache-miss failure mode |
| `true`, credentials present | authenticated pool; the username is logged, the password never is |
| `true`, username or password blank | `IllegalStateException` at bean creation, naming the offending `host:port` |

Blank covers `null`, `""` and whitespace. This matters because Jedis sends the two-argument `AUTH` whenever the username is non-null, so an empty username yields `WRONGPASS` on every command instead of a clear failure.

The two instances are configured independently — one may use ACLs while the other does not.

### The part worth reviewing closely

This service needed something #345 did not. **`searchResultRedisTemplate` builds its own `JedisConnectionFactory` and does not go through either pool**, yet `AchievementServiceImpl` injects it. Authenticating only the pools would have produced a service where caching works and achievements fail with `NOAUTH` — arguably worse than the original bug, because it is half-broken rather than uniformly broken.

It reaches the **cache** instance, so it takes the `redis.*` credentials, never `redis.data.*`. Two details:

- `JedisConnectionFactory` exposes `setPassword` but has **no `setUsername`** in spring-data-redis 3.2.0, so the username is applied via `getStandaloneConfiguration()`.
- Both must be set **before** the existing `afterPropertiesSet()` call.

The credential validation is factored into `requireCredentials(...)` precisely because the cache credentials now have two consumers reaching the same server by different routes.

### Testing

`mvn clean test` — **1020 tests pass** (1014 before; 6 added). `mvn verify` green, JaCoCo coverage gate met. The authenticated path was additionally verified end-to-end: username and password land correctly on the standalone configuration. No pom changes: `commons-lang3` and a Jedis carrying the auth constructors were already on the classpath.